### PR TITLE
Support stack and global blocks

### DIFF
--- a/src/avf_audio.zig
+++ b/src/avf_audio.zig
@@ -96,16 +96,8 @@ pub const AVAudioSession = opaque {
             pub fn setAllowHapticsAndSystemSoundsDuringRecording_error(self_: *T, inValue_: bool, outError_: ?*?*ns.Error) bool {
                 return @as(*const fn (*T, *c.objc_selector, bool, ?*?*ns.Error) callconv(.C) bool, @ptrCast(&c.objc_msgSend))(self_, sel_setAllowHapticsAndSystemSoundsDuringRecording_error_, inValue_, outError_);
             }
-            pub fn requestRecordPermission(self_: *T, context: anytype, comptime response_: fn (ctx: @TypeOf(context), _: bool) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: bool) callconv(.C) void {
-                        response_(literal.context, a0);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_requestRecordPermission_, @ptrCast(&block));
+            pub fn requestRecordPermission(self_: *T, response_: *ns.Block(fn (bool) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_requestRecordPermission_, response_);
             }
             pub fn overrideOutputAudioPort_error(self_: *T, portOverride_: AVAudioSessionPortOverride, outError_: ?*?*ns.Error) bool {
                 return @as(*const fn (*T, *c.objc_selector, AVAudioSessionPortOverride, ?*?*ns.Error) callconv(.C) bool, @ptrCast(&c.objc_msgSend))(self_, sel_overrideOutputAudioPort_error_, portOverride_, outError_);
@@ -152,16 +144,8 @@ pub const AVAudioSession = opaque {
             pub fn setActive_withOptions_error(self_: *T, active_: bool, options_: AVAudioSessionSetActiveOptions, outError_: ?*?*ns.Error) bool {
                 return @as(*const fn (*T, *c.objc_selector, bool, AVAudioSessionSetActiveOptions, ?*?*ns.Error) callconv(.C) bool, @ptrCast(&c.objc_msgSend))(self_, sel_setActive_withOptions_error_, active_, options_, outError_);
             }
-            pub fn activateWithOptions_completionHandler(self_: *T, options_: AVAudioSessionActivationOptions, context: anytype, comptime handler_: fn (ctx: @TypeOf(context), _: bool, _: ?*ns.Error) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: bool, a1: ?*ns.Error) callconv(.C) void {
-                        handler_(literal.context, a0, a1);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, AVAudioSessionActivationOptions, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_activateWithOptions_completionHandler_, options_, @ptrCast(&block));
+            pub fn activateWithOptions_completionHandler(self_: *T, options_: AVAudioSessionActivationOptions, handler_: *ns.Block(fn (bool, ?*ns.Error) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, AVAudioSessionActivationOptions, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_activateWithOptions_completionHandler_, options_, handler_);
             }
             pub fn setPreferredSampleRate_error(self_: *T, sampleRate_: f64, outError_: ?*?*ns.Error) bool {
                 return @as(*const fn (*T, *c.objc_selector, f64, ?*?*ns.Error) callconv(.C) bool, @ptrCast(&c.objc_msgSend))(self_, sel_setPreferredSampleRate_error_, sampleRate_, outError_);

--- a/src/main.zig
+++ b/src/main.zig
@@ -39,11 +39,11 @@ pub const mach = struct {
         }
         extern "objc" fn objc_alloc_init(class: *anyopaque) *AppDelegate;
 
-        pub fn setRunBlock(self: *AppDelegate, block: *anyopaque) void {
+        pub fn setRunBlock(self: *AppDelegate, block: *foundation.ns.Block(fn () void)) void {
             method(self, block);
         }
         const method = @extern(
-            *const fn (*AppDelegate, *anyopaque) callconv(.C) void,
+            *const fn (*AppDelegate, *foundation.ns.Block(fn () void)) callconv(.C) void,
             .{ .name = "\x01-[MACHAppDelegate setRunBlock:]" },
         );
     };

--- a/src/metal.zig
+++ b/src/metal.zig
@@ -2659,16 +2659,8 @@ pub const CommandBuffer = opaque {
             pub fn commit(self_: *T) void {
                 return @as(*const fn (*T, *c.objc_selector) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_commit);
             }
-            pub fn addScheduledHandler(self_: *T, context: anytype, comptime block_: fn (ctx: @TypeOf(context), _: *CommandBuffer) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: *CommandBuffer) callconv(.C) void {
-                        block_(literal.context, a0);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_addScheduledHandler_, @ptrCast(&block));
+            pub fn addScheduledHandler(self_: *T, block_: *ns.Block(fn (*CommandBuffer) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_addScheduledHandler_, block_);
             }
             pub fn presentDrawable(self_: *T, drawable_: *Drawable) void {
                 return @as(*const fn (*T, *c.objc_selector, *Drawable) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_presentDrawable_, drawable_);
@@ -2682,16 +2674,8 @@ pub const CommandBuffer = opaque {
             pub fn waitUntilScheduled(self_: *T) void {
                 return @as(*const fn (*T, *c.objc_selector) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_waitUntilScheduled);
             }
-            pub fn addCompletedHandler(self_: *T, context: anytype, comptime block_: fn (ctx: @TypeOf(context), _: *CommandBuffer) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: *CommandBuffer) callconv(.C) void {
-                        block_(literal.context, a0);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_addCompletedHandler_, @ptrCast(&block));
+            pub fn addCompletedHandler(self_: *T, block_: *ns.Block(fn (*CommandBuffer) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_addCompletedHandler_, block_);
             }
             pub fn waitUntilCompleted(self_: *T) void {
                 return @as(*const fn (*T, *c.objc_selector) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_waitUntilCompleted);
@@ -3522,16 +3506,8 @@ pub const Device = opaque {
             pub fn newBufferWithBytes_length_options(self_: *T, pointer_: *const anyopaque, length_: ns.UInteger, options_: ResourceOptions) ?*Buffer {
                 return @as(*const fn (*T, *c.objc_selector, *const anyopaque, ns.UInteger, ResourceOptions) callconv(.C) ?*Buffer, @ptrCast(&c.objc_msgSend))(self_, sel_newBufferWithBytes_length_options_, pointer_, length_, options_);
             }
-            pub fn newBufferWithBytesNoCopy_length_options_deallocator(self_: *T, pointer_: *anyopaque, length_: ns.UInteger, options_: ResourceOptions, context: anytype, comptime deallocator_: fn (ctx: @TypeOf(context), _: *anyopaque, _: ns.UInteger) void) ?*Buffer {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: *anyopaque, a1: ns.UInteger) callconv(.C) void {
-                        deallocator_(literal.context, a0, a1);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *anyopaque, ns.UInteger, ResourceOptions, *const anyopaque) callconv(.C) ?*Buffer, @ptrCast(&c.objc_msgSend))(self_, sel_newBufferWithBytesNoCopy_length_options_deallocator_, pointer_, length_, options_, @ptrCast(&block));
+            pub fn newBufferWithBytesNoCopy_length_options_deallocator(self_: *T, pointer_: *anyopaque, length_: ns.UInteger, options_: ResourceOptions, deallocator_: *ns.Block(fn (*anyopaque, ns.UInteger) void)) ?*Buffer {
+                return @as(*const fn (*T, *c.objc_selector, *anyopaque, ns.UInteger, ResourceOptions, *const anyopaque) callconv(.C) ?*Buffer, @ptrCast(&c.objc_msgSend))(self_, sel_newBufferWithBytesNoCopy_length_options_deallocator_, pointer_, length_, options_, deallocator_);
             }
             pub fn newDepthStencilStateWithDescriptor(self_: *T, descriptor_: *DepthStencilDescriptor) ?*DepthStencilState {
                 return @as(*const fn (*T, *c.objc_selector, *DepthStencilDescriptor) callconv(.C) ?*DepthStencilState, @ptrCast(&c.objc_msgSend))(self_, sel_newDepthStencilStateWithDescriptor_, descriptor_);
@@ -3569,30 +3545,14 @@ pub const Device = opaque {
             pub fn newLibraryWithSource_options_error(self_: *T, source_: *ns.String, options_: ?*CompileOptions, error_: ?*?*ns.Error) ?*Library {
                 return @as(*const fn (*T, *c.objc_selector, *ns.String, ?*CompileOptions, ?*?*ns.Error) callconv(.C) ?*Library, @ptrCast(&c.objc_msgSend))(self_, sel_newLibraryWithSource_options_error_, source_, options_, error_);
             }
-            pub fn newLibraryWithSource_options_completionHandler(self_: *T, source_: *ns.String, options_: ?*CompileOptions, context: anytype, comptime completionHandler_: fn (ctx: @TypeOf(context), _: ?*Library, _: ?*ns.Error) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: ?*Library, a1: ?*ns.Error) callconv(.C) void {
-                        completionHandler_(literal.context, a0, a1);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *ns.String, ?*CompileOptions, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newLibraryWithSource_options_completionHandler_, source_, options_, @ptrCast(&block));
+            pub fn newLibraryWithSource_options_completionHandler(self_: *T, source_: *ns.String, options_: ?*CompileOptions, completionHandler_: *ns.Block(fn (?*Library, ?*ns.Error) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *ns.String, ?*CompileOptions, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newLibraryWithSource_options_completionHandler_, source_, options_, completionHandler_);
             }
             pub fn newLibraryWithStitchedDescriptor_error(self_: *T, descriptor_: *StitchedLibraryDescriptor, error_: ?*?*ns.Error) ?*Library {
                 return @as(*const fn (*T, *c.objc_selector, *StitchedLibraryDescriptor, ?*?*ns.Error) callconv(.C) ?*Library, @ptrCast(&c.objc_msgSend))(self_, sel_newLibraryWithStitchedDescriptor_error_, descriptor_, error_);
             }
-            pub fn newLibraryWithStitchedDescriptor_completionHandler(self_: *T, descriptor_: *StitchedLibraryDescriptor, context: anytype, comptime completionHandler_: fn (ctx: @TypeOf(context), _: ?*Library, _: ?*ns.Error) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: ?*Library, a1: ?*ns.Error) callconv(.C) void {
-                        completionHandler_(literal.context, a0, a1);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *StitchedLibraryDescriptor, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newLibraryWithStitchedDescriptor_completionHandler_, descriptor_, @ptrCast(&block));
+            pub fn newLibraryWithStitchedDescriptor_completionHandler(self_: *T, descriptor_: *StitchedLibraryDescriptor, completionHandler_: *ns.Block(fn (?*Library, ?*ns.Error) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *StitchedLibraryDescriptor, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newLibraryWithStitchedDescriptor_completionHandler_, descriptor_, completionHandler_);
             }
             pub fn newRenderPipelineStateWithDescriptor_error(self_: *T, descriptor_: *RenderPipelineDescriptor, error_: ?*?*ns.Error) ?*RenderPipelineState {
                 return @as(*const fn (*T, *c.objc_selector, *RenderPipelineDescriptor, ?*?*ns.Error) callconv(.C) ?*RenderPipelineState, @ptrCast(&c.objc_msgSend))(self_, sel_newRenderPipelineStateWithDescriptor_error_, descriptor_, error_);
@@ -3600,27 +3560,11 @@ pub const Device = opaque {
             pub fn newRenderPipelineStateWithDescriptor_options_reflection_error(self_: *T, descriptor_: *RenderPipelineDescriptor, options_: PipelineOption, reflection_: ?*AutoreleasedRenderPipelineReflection, error_: ?*?*ns.Error) ?*RenderPipelineState {
                 return @as(*const fn (*T, *c.objc_selector, *RenderPipelineDescriptor, PipelineOption, ?*AutoreleasedRenderPipelineReflection, ?*?*ns.Error) callconv(.C) ?*RenderPipelineState, @ptrCast(&c.objc_msgSend))(self_, sel_newRenderPipelineStateWithDescriptor_options_reflection_error_, descriptor_, options_, reflection_, error_);
             }
-            pub fn newRenderPipelineStateWithDescriptor_completionHandler(self_: *T, descriptor_: *RenderPipelineDescriptor, context: anytype, comptime completionHandler_: fn (ctx: @TypeOf(context), _: ?*RenderPipelineState, _: ?*ns.Error) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: ?*RenderPipelineState, a1: ?*ns.Error) callconv(.C) void {
-                        completionHandler_(literal.context, a0, a1);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *RenderPipelineDescriptor, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newRenderPipelineStateWithDescriptor_completionHandler_, descriptor_, @ptrCast(&block));
+            pub fn newRenderPipelineStateWithDescriptor_completionHandler(self_: *T, descriptor_: *RenderPipelineDescriptor, completionHandler_: *ns.Block(fn (?*RenderPipelineState, ?*ns.Error) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *RenderPipelineDescriptor, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newRenderPipelineStateWithDescriptor_completionHandler_, descriptor_, completionHandler_);
             }
-            pub fn newRenderPipelineStateWithDescriptor_options_completionHandler(self_: *T, descriptor_: *RenderPipelineDescriptor, options_: PipelineOption, context: anytype, comptime completionHandler_: fn (ctx: @TypeOf(context), _: ?*RenderPipelineState, _: *RenderPipelineReflection, _: ?*ns.Error) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: ?*RenderPipelineState, a1: *RenderPipelineReflection, a2: ?*ns.Error) callconv(.C) void {
-                        completionHandler_(literal.context, a0, a1, a2);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *RenderPipelineDescriptor, PipelineOption, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newRenderPipelineStateWithDescriptor_options_completionHandler_, descriptor_, options_, @ptrCast(&block));
+            pub fn newRenderPipelineStateWithDescriptor_options_completionHandler(self_: *T, descriptor_: *RenderPipelineDescriptor, options_: PipelineOption, completionHandler_: *ns.Block(fn (?*RenderPipelineState, *RenderPipelineReflection, ?*ns.Error) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *RenderPipelineDescriptor, PipelineOption, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newRenderPipelineStateWithDescriptor_options_completionHandler_, descriptor_, options_, completionHandler_);
             }
             pub fn newComputePipelineStateWithFunction_error(self_: *T, computeFunction_: *Function, error_: ?*?*ns.Error) ?*ComputePipelineState {
                 return @as(*const fn (*T, *c.objc_selector, *Function, ?*?*ns.Error) callconv(.C) ?*ComputePipelineState, @ptrCast(&c.objc_msgSend))(self_, sel_newComputePipelineStateWithFunction_error_, computeFunction_, error_);
@@ -3628,41 +3572,17 @@ pub const Device = opaque {
             pub fn newComputePipelineStateWithFunction_options_reflection_error(self_: *T, computeFunction_: *Function, options_: PipelineOption, reflection_: ?*AutoreleasedComputePipelineReflection, error_: ?*?*ns.Error) ?*ComputePipelineState {
                 return @as(*const fn (*T, *c.objc_selector, *Function, PipelineOption, ?*AutoreleasedComputePipelineReflection, ?*?*ns.Error) callconv(.C) ?*ComputePipelineState, @ptrCast(&c.objc_msgSend))(self_, sel_newComputePipelineStateWithFunction_options_reflection_error_, computeFunction_, options_, reflection_, error_);
             }
-            pub fn newComputePipelineStateWithFunction_completionHandler(self_: *T, computeFunction_: *Function, context: anytype, comptime completionHandler_: fn (ctx: @TypeOf(context), _: ?*ComputePipelineState, _: ?*ns.Error) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: ?*ComputePipelineState, a1: ?*ns.Error) callconv(.C) void {
-                        completionHandler_(literal.context, a0, a1);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *Function, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newComputePipelineStateWithFunction_completionHandler_, computeFunction_, @ptrCast(&block));
+            pub fn newComputePipelineStateWithFunction_completionHandler(self_: *T, computeFunction_: *Function, completionHandler_: *ns.Block(fn (?*ComputePipelineState, ?*ns.Error) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *Function, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newComputePipelineStateWithFunction_completionHandler_, computeFunction_, completionHandler_);
             }
-            pub fn newComputePipelineStateWithFunction_options_completionHandler(self_: *T, computeFunction_: *Function, options_: PipelineOption, context: anytype, comptime completionHandler_: fn (ctx: @TypeOf(context), _: ?*ComputePipelineState, _: *ComputePipelineReflection, _: ?*ns.Error) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: ?*ComputePipelineState, a1: *ComputePipelineReflection, a2: ?*ns.Error) callconv(.C) void {
-                        completionHandler_(literal.context, a0, a1, a2);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *Function, PipelineOption, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newComputePipelineStateWithFunction_options_completionHandler_, computeFunction_, options_, @ptrCast(&block));
+            pub fn newComputePipelineStateWithFunction_options_completionHandler(self_: *T, computeFunction_: *Function, options_: PipelineOption, completionHandler_: *ns.Block(fn (?*ComputePipelineState, *ComputePipelineReflection, ?*ns.Error) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *Function, PipelineOption, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newComputePipelineStateWithFunction_options_completionHandler_, computeFunction_, options_, completionHandler_);
             }
             pub fn newComputePipelineStateWithDescriptor_options_reflection_error(self_: *T, descriptor_: *ComputePipelineDescriptor, options_: PipelineOption, reflection_: ?*AutoreleasedComputePipelineReflection, error_: ?*?*ns.Error) ?*ComputePipelineState {
                 return @as(*const fn (*T, *c.objc_selector, *ComputePipelineDescriptor, PipelineOption, ?*AutoreleasedComputePipelineReflection, ?*?*ns.Error) callconv(.C) ?*ComputePipelineState, @ptrCast(&c.objc_msgSend))(self_, sel_newComputePipelineStateWithDescriptor_options_reflection_error_, descriptor_, options_, reflection_, error_);
             }
-            pub fn newComputePipelineStateWithDescriptor_options_completionHandler(self_: *T, descriptor_: *ComputePipelineDescriptor, options_: PipelineOption, context: anytype, comptime completionHandler_: fn (ctx: @TypeOf(context), _: ?*ComputePipelineState, _: *ComputePipelineReflection, _: ?*ns.Error) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: ?*ComputePipelineState, a1: *ComputePipelineReflection, a2: ?*ns.Error) callconv(.C) void {
-                        completionHandler_(literal.context, a0, a1, a2);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *ComputePipelineDescriptor, PipelineOption, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newComputePipelineStateWithDescriptor_options_completionHandler_, descriptor_, options_, @ptrCast(&block));
+            pub fn newComputePipelineStateWithDescriptor_options_completionHandler(self_: *T, descriptor_: *ComputePipelineDescriptor, options_: PipelineOption, completionHandler_: *ns.Block(fn (?*ComputePipelineState, *ComputePipelineReflection, ?*ns.Error) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *ComputePipelineDescriptor, PipelineOption, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newComputePipelineStateWithDescriptor_options_completionHandler_, descriptor_, options_, completionHandler_);
             }
             pub fn newFence(self_: *T) ?*Fence {
                 return @as(*const fn (*T, *c.objc_selector) callconv(.C) ?*Fence, @ptrCast(&c.objc_msgSend))(self_, sel_newFence);
@@ -3685,30 +3605,14 @@ pub const Device = opaque {
             pub fn newRenderPipelineStateWithTileDescriptor_options_reflection_error(self_: *T, descriptor_: *TileRenderPipelineDescriptor, options_: PipelineOption, reflection_: ?*AutoreleasedRenderPipelineReflection, error_: ?*?*ns.Error) ?*RenderPipelineState {
                 return @as(*const fn (*T, *c.objc_selector, *TileRenderPipelineDescriptor, PipelineOption, ?*AutoreleasedRenderPipelineReflection, ?*?*ns.Error) callconv(.C) ?*RenderPipelineState, @ptrCast(&c.objc_msgSend))(self_, sel_newRenderPipelineStateWithTileDescriptor_options_reflection_error_, descriptor_, options_, reflection_, error_);
             }
-            pub fn newRenderPipelineStateWithTileDescriptor_options_completionHandler(self_: *T, descriptor_: *TileRenderPipelineDescriptor, options_: PipelineOption, context: anytype, comptime completionHandler_: fn (ctx: @TypeOf(context), _: ?*RenderPipelineState, _: *RenderPipelineReflection, _: ?*ns.Error) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: ?*RenderPipelineState, a1: *RenderPipelineReflection, a2: ?*ns.Error) callconv(.C) void {
-                        completionHandler_(literal.context, a0, a1, a2);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *TileRenderPipelineDescriptor, PipelineOption, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newRenderPipelineStateWithTileDescriptor_options_completionHandler_, descriptor_, options_, @ptrCast(&block));
+            pub fn newRenderPipelineStateWithTileDescriptor_options_completionHandler(self_: *T, descriptor_: *TileRenderPipelineDescriptor, options_: PipelineOption, completionHandler_: *ns.Block(fn (?*RenderPipelineState, *RenderPipelineReflection, ?*ns.Error) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *TileRenderPipelineDescriptor, PipelineOption, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newRenderPipelineStateWithTileDescriptor_options_completionHandler_, descriptor_, options_, completionHandler_);
             }
             pub fn newRenderPipelineStateWithMeshDescriptor_options_reflection_error(self_: *T, descriptor_: *MeshRenderPipelineDescriptor, options_: PipelineOption, reflection_: ?*AutoreleasedRenderPipelineReflection, error_: ?*?*ns.Error) ?*RenderPipelineState {
                 return @as(*const fn (*T, *c.objc_selector, *MeshRenderPipelineDescriptor, PipelineOption, ?*AutoreleasedRenderPipelineReflection, ?*?*ns.Error) callconv(.C) ?*RenderPipelineState, @ptrCast(&c.objc_msgSend))(self_, sel_newRenderPipelineStateWithMeshDescriptor_options_reflection_error_, descriptor_, options_, reflection_, error_);
             }
-            pub fn newRenderPipelineStateWithMeshDescriptor_options_completionHandler(self_: *T, descriptor_: *MeshRenderPipelineDescriptor, options_: PipelineOption, context: anytype, comptime completionHandler_: fn (ctx: @TypeOf(context), _: ?*RenderPipelineState, _: *RenderPipelineReflection, _: ?*ns.Error) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: ?*RenderPipelineState, a1: *RenderPipelineReflection, a2: ?*ns.Error) callconv(.C) void {
-                        completionHandler_(literal.context, a0, a1, a2);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *MeshRenderPipelineDescriptor, PipelineOption, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newRenderPipelineStateWithMeshDescriptor_options_completionHandler_, descriptor_, options_, @ptrCast(&block));
+            pub fn newRenderPipelineStateWithMeshDescriptor_options_completionHandler(self_: *T, descriptor_: *MeshRenderPipelineDescriptor, options_: PipelineOption, completionHandler_: *ns.Block(fn (?*RenderPipelineState, *RenderPipelineReflection, ?*ns.Error) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *MeshRenderPipelineDescriptor, PipelineOption, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newRenderPipelineStateWithMeshDescriptor_options_completionHandler_, descriptor_, options_, completionHandler_);
             }
             pub fn getDefaultSamplePositions_count(self_: *T, positions_: *SamplePosition, count_: ns.UInteger) void {
                 return @as(*const fn (*T, *c.objc_selector, *SamplePosition, ns.UInteger) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_getDefaultSamplePositions_count_, positions_, count_);
@@ -3952,16 +3856,8 @@ pub const Drawable = opaque {
             pub fn presentAfterMinimumDuration(self_: *T, duration_: cf.TimeInterval) void {
                 return @as(*const fn (*T, *c.objc_selector, cf.TimeInterval) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_presentAfterMinimumDuration_, duration_);
             }
-            pub fn addPresentedHandler(self_: *T, context: anytype, comptime block_: fn (ctx: @TypeOf(context), _: *Drawable) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: *Drawable) callconv(.C) void {
-                        block_(literal.context, a0);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_addPresentedHandler_, @ptrCast(&block));
+            pub fn addPresentedHandler(self_: *T, block_: *ns.Block(fn (*Drawable) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_addPresentedHandler_, block_);
             }
             pub fn presentedTime(self_: *T) cf.TimeInterval {
                 return @as(*const fn (*T, *c.objc_selector) callconv(.C) cf.TimeInterval, @ptrCast(&c.objc_msgSend))(self_, sel_presentedTime);
@@ -4046,16 +3942,8 @@ pub const SharedEvent = opaque {
         return struct {
             pub usingnamespace Event.Methods(T);
 
-            pub fn notifyListener_atValue_block(self_: *T, listener_: *SharedEventListener, value_: u64, context: anytype, comptime block_: fn (ctx: @TypeOf(context), _: *SharedEvent, _: u64) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: *SharedEvent, a1: u64) callconv(.C) void {
-                        block_(literal.context, a0, a1);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *SharedEventListener, u64, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_notifyListener_atValue_block_, listener_, value_, @ptrCast(&block));
+            pub fn notifyListener_atValue_block(self_: *T, listener_: *SharedEventListener, value_: u64, block_: *ns.Block(fn (*SharedEvent, u64) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *SharedEventListener, u64, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_notifyListener_atValue_block_, listener_, value_, block_);
             }
             pub fn newSharedEventHandle(self_: *T) *SharedEventHandle {
                 return @as(*const fn (*T, *c.objc_selector) callconv(.C) *SharedEventHandle, @ptrCast(&c.objc_msgSend))(self_, sel_newSharedEventHandle);
@@ -4859,16 +4747,8 @@ pub const IOCommandBuffer = opaque {
         return struct {
             pub usingnamespace ns.ObjectProtocol.Methods(T);
 
-            pub fn addCompletedHandler(self_: *T, context: anytype, comptime block_: fn (ctx: @TypeOf(context), _: *IOCommandBuffer) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: *IOCommandBuffer) callconv(.C) void {
-                        block_(literal.context, a0);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_addCompletedHandler_, @ptrCast(&block));
+            pub fn addCompletedHandler(self_: *T, block_: *ns.Block(fn (*IOCommandBuffer) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_addCompletedHandler_, block_);
             }
             pub fn loadBytes_size_sourceHandle_sourceHandleOffset(self_: *T, pointer_: *anyopaque, size_: ns.UInteger, sourceHandle_: *IOFileHandle, sourceHandleOffset_: ns.UInteger) void {
                 return @as(*const fn (*T, *c.objc_selector, *anyopaque, ns.UInteger, *IOFileHandle, ns.UInteger) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_loadBytes_size_sourceHandle_sourceHandleOffset_, pointer_, size_, sourceHandle_, sourceHandleOffset_);
@@ -5275,41 +5155,17 @@ pub const Library = opaque {
             pub fn newFunctionWithName_constantValues_error(self_: *T, name_: *ns.String, constantValues_: *FunctionConstantValues, error_: ?*?*ns.Error) ?*Function {
                 return @as(*const fn (*T, *c.objc_selector, *ns.String, *FunctionConstantValues, ?*?*ns.Error) callconv(.C) ?*Function, @ptrCast(&c.objc_msgSend))(self_, sel_newFunctionWithName_constantValues_error_, name_, constantValues_, error_);
             }
-            pub fn newFunctionWithName_constantValues_completionHandler(self_: *T, name_: *ns.String, constantValues_: *FunctionConstantValues, context: anytype, comptime completionHandler_: fn (ctx: @TypeOf(context), _: ?*Function, _: ?*ns.Error) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: ?*Function, a1: ?*ns.Error) callconv(.C) void {
-                        completionHandler_(literal.context, a0, a1);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *ns.String, *FunctionConstantValues, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newFunctionWithName_constantValues_completionHandler_, name_, constantValues_, @ptrCast(&block));
+            pub fn newFunctionWithName_constantValues_completionHandler(self_: *T, name_: *ns.String, constantValues_: *FunctionConstantValues, completionHandler_: *ns.Block(fn (?*Function, ?*ns.Error) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *ns.String, *FunctionConstantValues, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newFunctionWithName_constantValues_completionHandler_, name_, constantValues_, completionHandler_);
             }
-            pub fn newFunctionWithDescriptor_completionHandler(self_: *T, descriptor_: *FunctionDescriptor, context: anytype, comptime completionHandler_: fn (ctx: @TypeOf(context), _: ?*Function, _: ?*ns.Error) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: ?*Function, a1: ?*ns.Error) callconv(.C) void {
-                        completionHandler_(literal.context, a0, a1);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *FunctionDescriptor, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newFunctionWithDescriptor_completionHandler_, descriptor_, @ptrCast(&block));
+            pub fn newFunctionWithDescriptor_completionHandler(self_: *T, descriptor_: *FunctionDescriptor, completionHandler_: *ns.Block(fn (?*Function, ?*ns.Error) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *FunctionDescriptor, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newFunctionWithDescriptor_completionHandler_, descriptor_, completionHandler_);
             }
             pub fn newFunctionWithDescriptor_error(self_: *T, descriptor_: *FunctionDescriptor, error_: ?*?*ns.Error) ?*Function {
                 return @as(*const fn (*T, *c.objc_selector, *FunctionDescriptor, ?*?*ns.Error) callconv(.C) ?*Function, @ptrCast(&c.objc_msgSend))(self_, sel_newFunctionWithDescriptor_error_, descriptor_, error_);
             }
-            pub fn newIntersectionFunctionWithDescriptor_completionHandler(self_: *T, descriptor_: *IntersectionFunctionDescriptor, context: anytype, comptime completionHandler_: fn (ctx: @TypeOf(context), _: ?*Function, _: ?*ns.Error) void) void {
-                const Literal = ns.BlockLiteral(@TypeOf(context));
-                const Helper = struct {
-                    pub fn cCallback(literal: *Literal, a0: ?*Function, a1: ?*ns.Error) callconv(.C) void {
-                        completionHandler_(literal.context, a0, a1);
-                    }
-                };
-                const descriptor = ns.BlockDescriptor{ .reserved = 0, .size = @sizeOf(Literal) };
-                const block = Literal{ .isa = _NSConcreteStackBlock, .flags = 0, .reserved = 0, .invoke = @ptrCast(&Helper.cCallback), .descriptor = &descriptor, .context = context };
-                return @as(*const fn (*T, *c.objc_selector, *IntersectionFunctionDescriptor, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newIntersectionFunctionWithDescriptor_completionHandler_, descriptor_, @ptrCast(&block));
+            pub fn newIntersectionFunctionWithDescriptor_completionHandler(self_: *T, descriptor_: *IntersectionFunctionDescriptor, completionHandler_: *ns.Block(fn (?*Function, ?*ns.Error) void)) void {
+                return @as(*const fn (*T, *c.objc_selector, *IntersectionFunctionDescriptor, *const anyopaque) callconv(.C) void, @ptrCast(&c.objc_msgSend))(self_, sel_newIntersectionFunctionWithDescriptor_completionHandler_, descriptor_, completionHandler_);
             }
             pub fn newIntersectionFunctionWithDescriptor_error(self_: *T, descriptor_: *IntersectionFunctionDescriptor, error_: ?*?*ns.Error) ?*Function {
                 return @as(*const fn (*T, *c.objc_selector, *IntersectionFunctionDescriptor, ?*?*ns.Error) callconv(.C) ?*Function, @ptrCast(&c.objc_msgSend))(self_, sel_newIntersectionFunctionWithDescriptor_error_, descriptor_, error_);

--- a/src/system.zig
+++ b/src/system.zig
@@ -1,0 +1,201 @@
+const builtin = @import("builtin");
+const std = @import("std");
+
+pub extern "System" fn dispatch_async(queue: *anyopaque, work: *const Block(fn (*BlockLiteral(void)) void)) void;
+pub extern "System" fn dispatch_async_f(queue: *anyopaque, context: ?*anyopaque, work: *const fn (context: ?*anyopaque) callconv(.C) void) void;
+pub extern "System" fn @"dispatch_assert_queue$V2"(queue: *anyopaque) void;
+pub extern "System" var _dispatch_main_q: anyopaque;
+
+extern fn _Block_copy(*const anyopaque) *anyopaque; // Provided by libSystem on iOS but not macOS.
+extern fn _Block_release(*const anyopaque) void; // Provided by libSystem on iOS but not macOS.
+
+pub fn Block(comptime Signature: type) type {
+    const signature_fn_info = @typeInfo(Signature).Fn;
+    return opaque {
+        pub fn invoke(self: *@This(), args: std.meta.ArgsTuple(Signature)) signature_fn_info.return_type.? {
+            const self_param = std.builtin.Type.Fn.Param{
+                .is_generic = false,
+                .is_noalias = false,
+                .type = *@This(),
+            };
+            const SignatureForInvoke = @Type(.{
+                .Fn = .{
+                    .calling_convention = .C,
+                    .is_generic = signature_fn_info.is_generic,
+                    .is_var_args = signature_fn_info.is_var_args,
+                    .return_type = signature_fn_info.return_type,
+                    .params = .{self_param} ++ signature_fn_info.params,
+                },
+            });
+
+            const offset = @offsetOf(BlockLiteral(void), "invoke");
+            const invoke_ptr: *const SignatureForInvoke = @ptrCast(self + offset);
+            return @call(.auto, invoke_ptr, .{self} ++ args);
+        }
+
+        pub fn copy(self: *const @This()) *@This() {
+            return @ptrCast(_Block_copy(self));
+        }
+
+        pub fn release(self: *const @This()) void {
+            _Block_release(self);
+        }
+    };
+}
+
+pub fn BlockLiteral(comptime Context: type) type {
+    return extern struct {
+        isa: *anyopaque,
+        flags: i32,
+        reserved: i32 = 0,
+        invoke: *const anyopaque,
+        descriptor: *const anyopaque,
+        context: Context,
+
+        fn trivialStaticDescriptor() *const anyopaque {
+            return TrivialBlockDescriptor.static(@sizeOf(@This()));
+        }
+
+        fn copyDisposeStaticDescriptor(comptime copy: anytype, comptime dispose: anytype) *const anyopaque {
+            return CopyDisposeBlockDescriptor(Context).static(@sizeOf(@This()), copy, dispose);
+        }
+
+        pub fn asBlockWithSignature(self: *@This(), comptime Signature: type) *Block(Signature) {
+            return @ptrCast(self);
+        }
+
+        pub fn release(self: *const @This()) void {
+            _Block_release(self);
+        }
+    };
+}
+
+pub fn BlockLiteralWithSignature(comptime Context: type, comptime Signature: type) type {
+    // We could also obtain `Context` from `@typeInfo(Signature).Fn.params[0].type`.
+    return extern struct {
+        literal: BlockLiteral(Context),
+
+        pub fn asBlock(self: *@This()) *Block(Signature) {
+            return self.literal.asBlockWithSignature(Signature);
+        }
+    };
+}
+
+const TrivialBlockDescriptor = extern struct {
+    reserved: c_ulong = 0,
+    size: c_ulong,
+
+    fn static(comptime size: c_ulong) *const TrivialBlockDescriptor {
+        const Static = struct {
+            const descriptor: TrivialBlockDescriptor = .{ .size = size };
+        };
+        return &Static.descriptor;
+    }
+};
+
+fn CopyDisposeBlockDescriptor(comptime Context: type) type {
+    return extern struct {
+        reserved: c_ulong = 0,
+        size: c_ulong,
+        copy: *const CopyFn,
+        dispose: *const DisposeFn,
+
+        pub const CopyFn = fn (dst: *BlockLiteral(Context), src: *const BlockLiteral(Context)) callconv(.C) void;
+        pub const DisposeFn = fn (block: *const BlockLiteral(Context)) callconv(.C) void;
+
+        fn static(comptime size: c_ulong, comptime copy: CopyFn, comptime dispose: DisposeFn) *const CopyDisposeBlockDescriptor {
+            const Static = struct {
+                const descriptor: CopyDisposeBlockDescriptor = .{
+                    .size = size,
+                    .copy = copy,
+                    .dispose = dispose,
+                };
+            };
+            return &Static.descriptor;
+        }
+    };
+}
+
+fn SignatureWithoutBlockLiteral(comptime Signature: type) type {
+    var type_info = @typeInfo(Signature);
+    type_info.Fn.calling_convention = .Unspecified;
+    type_info.Fn.params = type_info.Fn.params[1..];
+    return @Type(type_info);
+}
+
+fn validateBlockSignature(comptime Invoke: type, comptime ExpectedLiteralType: type) void {
+    switch (@typeInfo(Invoke)) {
+        .Fn => |fn_info| {
+            if (fn_info.calling_convention != .C) {
+                @compileError("A block's `invoke` must use the C calling convention");
+            }
+
+            // TODO: should we allow zero params? At the ABI-level it would be fine but I think the compiler might consider it UB.
+            if (fn_info.params.len == 0 or fn_info.params[0].type != *ExpectedLiteralType) {
+                @compileError("The first parameter for a block's `invoke` must be a block literal pointer");
+            }
+        },
+        else => @compileError("A block's `invoke` must be a function"),
+    }
+}
+
+pub fn stackBlockLiteral(
+    invoke: anytype,
+    context: anytype,
+    comptime copy: ?fn (dst: *BlockLiteral(@TypeOf(context)), src: *const BlockLiteral(@TypeOf(context))) callconv(.C) void,
+    comptime dispose: ?fn (block: *const BlockLiteral(@TypeOf(context))) callconv(.C) void,
+) BlockLiteralWithSignature(@TypeOf(context), SignatureWithoutBlockLiteral(@TypeOf(invoke))) {
+    const Context = @TypeOf(context);
+    const Literal = BlockLiteral(Context);
+    comptime {
+        validateBlockSignature(@TypeOf(invoke), Literal);
+        if ((copy == null) != (dispose == null)) {
+            @compileError("Both `copy` and `dispose` must either be null or nonnull");
+        }
+    }
+    // const has_copy_dispose = if (comptime copy != null and dispose != null) 1 << 25 else 0;
+    const has_copy_dispose = comptime copy != null and dispose != null;
+    return .{
+        .literal = .{
+            .isa = _NSConcreteStackBlock,
+            .flags = if (has_copy_dispose) 1 << 25 else 0,
+            .invoke = invoke,
+            .descriptor = if (has_copy_dispose) Literal.copyDisposeStaticDescriptor(copy, dispose) else Literal.trivialStaticDescriptor(),
+            .context = context,
+        },
+    };
+}
+const _NSConcreteStackBlock = @extern(*anyopaque, .{
+    .name = "_NSConcreteStackBlock",
+    .library_name = if (builtin.target.os.tag == .macos) null else "System",
+});
+
+pub fn globalBlockLiteral(invoke: anytype, context: anytype) BlockLiteralWithSignature(@TypeOf(context), SignatureWithoutBlockLiteral(@TypeOf(invoke))) {
+    const Context = @TypeOf(context);
+    const Literal = BlockLiteral(Context);
+    comptime {
+        validateBlockSignature(@TypeOf(invoke), Literal);
+    }
+    const block_is_no_escape = 1 << 23;
+    const block_is_global = 1 << 28;
+    return .{
+        .literal = .{
+            .isa = _NSConcreteGlobalBlock,
+            .flags = block_is_no_escape | block_is_global,
+            .invoke = invoke,
+            .descriptor = Literal.trivialStaticDescriptor(),
+            .context = context,
+        },
+    };
+}
+const _NSConcreteGlobalBlock = @extern(*anyopaque, .{
+    .name = "_NSConcreteGlobalBlock",
+    .library_name = if (builtin.target.os.tag == .macos) null else "System",
+});
+
+pub fn globalBlock(comptime invoke: anytype) *Block(SignatureWithoutBlockLiteral(@TypeOf(invoke))) {
+    const Static = struct {
+        const literal = globalBlockLiteral(invoke, {});
+    };
+    return Static.literal.asBlock();
+}


### PR DESCRIPTION
There are five objectives here:

1. Make it so methods take the same number of parameters between Objective-C and Zig code. It's not a huge deal but it marginally simplifies parameter matching.
2. Make it easy to create block literals and consume them/invoke them.
3. Make it so users can manage resources with their blocks by providing copy/release functions.
4. Support global blocks, which have no-op copy/release implementations.
5. Reduce the number of levels of indirection and register shuffling with each invocation. This was done by making the invocation function take the block literal as a parameter instead of the previous implementation that used a dedicated helper to hide it.

General usage is something kinda like this:

```
const Context = extern struct {
    foo: i32,
    bar = f32,
};

const ctx = Context { .foo = 42, bar = 13.0 };
var block_literal = ns.stackBlockLiteral(function, ctx, null, null); // No resources to free, so no copy/release functions.
someFunctionThatConsumesBlocks(block_literal.asBlock());

// Can pass more parameters if block takes args, or return a value too.
fn function(block:  *ns.BlockLiteral(Context)) callconv(.C) void {
  std.debug.print("foo = {}, bar = {}\n", .{block.context.foo, block.context.bar});
}
```

There are two mildly annoying things here:

1. The function must be `callconv(.C)`. There's no way to avoid this without introducing additional indirection.
2. The block's context must be compatible with the C ABI (e.g., it can't be a tuple). We could work around this by making the context an (aligned) array of bytes and then provide a `context()` helper method that just returns `@as(*ContextType, @ptrCast(&block.context_bytes))`.

Note that this PR will require a corresponding update to the main Mach repo to consume the new block-related APIs.

Also note that I don't intend on publicly exposing the libSystem bindings. It's fine to do it, though. They're just low-level enough that they're not enjoyable to work with so wrapper APIs are better IMO.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.