### PR TITLE
Add NSWindow and NSWindowDelegate methods

### DIFF
--- a/MACHWindowDelegate.m
+++ b/MACHWindowDelegate.m
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+
+@interface MACHWindowDelegate : NSObject
+@end
+
+@implementation MACHWindowDelegate {
+    void (^_windowWillResize_toSize_block)(NSSize);
+}
+
+- (void)setBlock_windowWillResize_toSize:(void (^)(NSSize))windowWillResize_toSize_block __attribute__((objc_direct)) {
+    _windowWillResize_toSize_block = windowWillResize_toSize_block;
+}
+
+- (NSSize)windowWillResize:(NSWindow *)sender toSize:(NSSize)frameSize {
+    if (self->_windowWillResize_toSize_block) self->_windowWillResize_toSize_block(frameSize);
+    return frameSize;
+}
+@end

--- a/MACHWindowDelegate_arm64_apple_macos12.s
+++ b/MACHWindowDelegate_arm64_apple_macos12.s
@@ -1,0 +1,185 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.build_version macos, 12, 0
+	.private_extern	"-[MACHWindowDelegate setBlock_windowWillResize_toSize:]"
+	.globl	"-[MACHWindowDelegate setBlock_windowWillResize_toSize:]"
+	.p2align	2
+"-[MACHWindowDelegate setBlock_windowWillResize_toSize:]":
+	.cfi_startproc
+	cbz	x0, LBB0_2
+	stp	x20, x19, [sp, #-32]!
+	stp	x29, x30, [sp, #16]
+	.cfi_def_cfa_offset 32
+	.cfi_offset w30, -8
+	.cfi_offset w29, -16
+	.cfi_offset w19, -24
+	.cfi_offset w20, -32
+	mov	x19, x0
+	mov	x0, x1
+	bl	_objc_retainBlock
+	ldr	x8, [x19, #8]
+	ldp	x29, x30, [sp, #16]
+	mov	x9, x0
+	mov	x0, x8
+	str	x9, [x19, #8]
+	ldp	x20, x19, [sp], #32
+	b	_objc_release
+LBB0_2:
+	ret
+	.cfi_endproc
+
+	.p2align	2
+"-[MACHWindowDelegate windowWillResize:toSize:]":
+	.cfi_startproc
+	stp	d9, d8, [sp, #-32]!
+	stp	x29, x30, [sp, #16]
+	.cfi_def_cfa_offset 32
+	.cfi_offset w30, -8
+	.cfi_offset w29, -16
+	.cfi_offset b8, -24
+	.cfi_offset b9, -32
+	fmov	d8, d1
+	fmov	d9, d0
+	ldr	x0, [x0, #8]
+	cbz	x0, LBB1_2
+	fmov	d0, d9
+	fmov	d1, d8
+	ldr	x8, [x0, #16]
+	blr	x8
+LBB1_2:
+	ldp	x29, x30, [sp, #16]
+	fmov	d0, d9
+	fmov	d1, d8
+	ldp	d9, d8, [sp], #32
+	ret
+	.cfi_endproc
+
+	.p2align	2
+"-[MACHWindowDelegate .cxx_destruct]":
+	.cfi_startproc
+	add	x0, x0, #8
+	mov	x1, xzr
+	b	_objc_storeStrong
+	.cfi_endproc
+
+	.section	__TEXT,__objc_classname,cstring_literals
+l_OBJC_CLASS_NAME_:
+	.asciz	"MACHWindowDelegate"
+
+	.section	__DATA,__objc_const
+	.p2align	3, 0x0
+__OBJC_METACLASS_RO_$_MACHWindowDelegate:
+	.long	389
+	.long	40
+	.long	40
+	.space	4
+	.quad	0
+	.quad	l_OBJC_CLASS_NAME_
+	.quad	0
+	.quad	0
+	.quad	0
+	.quad	0
+	.quad	0
+
+	.section	__DATA,__objc_data
+	.globl	_OBJC_METACLASS_$_MACHWindowDelegate
+	.p2align	3, 0x0
+_OBJC_METACLASS_$_MACHWindowDelegate:
+	.quad	_OBJC_METACLASS_$_NSObject
+	.quad	_OBJC_METACLASS_$_NSObject
+	.quad	__objc_empty_cache
+	.quad	0
+	.quad	__OBJC_METACLASS_RO_$_MACHWindowDelegate
+
+	.section	__TEXT,__objc_classname,cstring_literals
+l_OBJC_CLASS_NAME_.1:
+	.asciz	"\001"
+
+	.section	__TEXT,__objc_methname,cstring_literals
+l_OBJC_METH_VAR_NAME_:
+	.asciz	"windowWillResize:toSize:"
+
+	.section	__TEXT,__objc_methtype,cstring_literals
+l_OBJC_METH_VAR_TYPE_:
+	.asciz	"{CGSize=dd}40@0:8@16{CGSize=dd}24"
+
+	.section	__TEXT,__objc_methname,cstring_literals
+l_OBJC_METH_VAR_NAME_.2:
+	.asciz	".cxx_destruct"
+
+	.section	__TEXT,__objc_methtype,cstring_literals
+l_OBJC_METH_VAR_TYPE_.3:
+	.asciz	"v16@0:8"
+
+	.section	__DATA,__objc_const
+	.p2align	3, 0x0
+__OBJC_$_INSTANCE_METHODS_MACHWindowDelegate:
+	.long	24
+	.long	2
+	.quad	l_OBJC_METH_VAR_NAME_
+	.quad	l_OBJC_METH_VAR_TYPE_
+	.quad	"-[MACHWindowDelegate windowWillResize:toSize:]"
+	.quad	l_OBJC_METH_VAR_NAME_.2
+	.quad	l_OBJC_METH_VAR_TYPE_.3
+	.quad	"-[MACHWindowDelegate .cxx_destruct]"
+
+	.private_extern	_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block
+	.section	__DATA,__objc_ivar
+	.globl	_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block
+	.p2align	2, 0x0
+_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block:
+	.long	8
+
+	.section	__TEXT,__objc_methname,cstring_literals
+l_OBJC_METH_VAR_NAME_.4:
+	.asciz	"_windowWillResize_toSize_block"
+
+	.section	__TEXT,__objc_methtype,cstring_literals
+l_OBJC_METH_VAR_TYPE_.5:
+	.asciz	"@?"
+
+	.section	__DATA,__objc_const
+	.p2align	3, 0x0
+__OBJC_$_INSTANCE_VARIABLES_MACHWindowDelegate:
+	.long	32
+	.long	1
+	.quad	_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block
+	.quad	l_OBJC_METH_VAR_NAME_.4
+	.quad	l_OBJC_METH_VAR_TYPE_.5
+	.long	3
+	.long	8
+
+	.p2align	3, 0x0
+__OBJC_CLASS_RO_$_MACHWindowDelegate:
+	.long	388
+	.long	8
+	.long	16
+	.space	4
+	.quad	l_OBJC_CLASS_NAME_.1
+	.quad	l_OBJC_CLASS_NAME_
+	.quad	__OBJC_$_INSTANCE_METHODS_MACHWindowDelegate
+	.quad	0
+	.quad	__OBJC_$_INSTANCE_VARIABLES_MACHWindowDelegate
+	.quad	0
+	.quad	0
+
+	.section	__DATA,__objc_data
+	.globl	_OBJC_CLASS_$_MACHWindowDelegate
+	.p2align	3, 0x0
+_OBJC_CLASS_$_MACHWindowDelegate:
+	.quad	_OBJC_METACLASS_$_MACHWindowDelegate
+	.quad	_OBJC_CLASS_$_NSObject
+	.quad	__objc_empty_cache
+	.quad	0
+	.quad	__OBJC_CLASS_RO_$_MACHWindowDelegate
+
+	.section	__DATA,__objc_classlist,regular,no_dead_strip
+	.p2align	3, 0x0
+l_OBJC_LABEL_CLASS_$:
+	.quad	_OBJC_CLASS_$_MACHWindowDelegate
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+L_OBJC_IMAGE_INFO:
+	.long	0
+	.long	64
+
+.subsections_via_symbols

--- a/MACHWindowDelegate_x86_64_apple_macos12.s
+++ b/MACHWindowDelegate_x86_64_apple_macos12.s
@@ -1,0 +1,177 @@
+	.section	__TEXT,__text,regular,pure_instructions
+	.build_version macos, 12, 0
+	.private_extern	"-[MACHWindowDelegate setBlock_windowWillResize_toSize:]"
+	.globl	"-[MACHWindowDelegate setBlock_windowWillResize_toSize:]"
+"-[MACHWindowDelegate setBlock_windowWillResize_toSize:]":
+	.cfi_startproc
+	pushq	%rbx
+	.cfi_def_cfa_offset 16
+	.cfi_offset %rbx, -16
+	testq	%rdi, %rdi
+	je	LBB0_1
+	movq	%rdi, %rbx
+	movq	%rsi, %rdi
+	callq	_objc_retainBlock
+	movq	8(%rbx), %rdi
+	movq	%rax, 8(%rbx)
+	popq	%rbx
+	jmpq	*_objc_release@GOTPCREL(%rip)
+LBB0_1:
+	popq	%rbx
+	retq
+	.cfi_endproc
+
+"-[MACHWindowDelegate windowWillResize:toSize:]":
+
+	.cfi_startproc
+	movq	8(%rdi), %rdi
+	testq	%rdi, %rdi
+	je	LBB1_2
+	subq	$24, %rsp
+	.cfi_def_cfa_offset 32
+	movsd	%xmm0, 8(%rsp)
+	movsd	8(%rsp), %xmm0
+
+	movsd	%xmm1, 16(%rsp)
+	movsd	16(%rsp), %xmm1
+
+	callq	*16(%rdi)
+	movsd	8(%rsp), %xmm0
+
+	movsd	16(%rsp), %xmm1
+
+	addq	$24, %rsp
+LBB1_2:
+	retq
+	.cfi_endproc
+
+"-[MACHWindowDelegate .cxx_destruct]":
+
+	.cfi_startproc
+	addq	$8, %rdi
+	xorl	%esi, %esi
+	jmp	_objc_storeStrong
+	.cfi_endproc
+
+	.section	__TEXT,__objc_classname,cstring_literals
+L_OBJC_CLASS_NAME_:
+	.asciz	"MACHWindowDelegate"
+
+	.section	__DATA,__objc_const
+	.p2align	3, 0x0
+__OBJC_METACLASS_RO_$_MACHWindowDelegate:
+	.long	389
+	.long	40
+	.long	40
+	.space	4
+	.quad	0
+	.quad	L_OBJC_CLASS_NAME_
+	.quad	0
+	.quad	0
+	.quad	0
+	.quad	0
+	.quad	0
+
+	.section	__DATA,__objc_data
+	.globl	_OBJC_METACLASS_$_MACHWindowDelegate
+	.p2align	3, 0x0
+_OBJC_METACLASS_$_MACHWindowDelegate:
+	.quad	_OBJC_METACLASS_$_NSObject
+	.quad	_OBJC_METACLASS_$_NSObject
+	.quad	__objc_empty_cache
+	.quad	0
+	.quad	__OBJC_METACLASS_RO_$_MACHWindowDelegate
+
+	.section	__TEXT,__objc_classname,cstring_literals
+L_OBJC_CLASS_NAME_.1:
+	.asciz	"\001"
+
+	.section	__TEXT,__objc_methname,cstring_literals
+L_OBJC_METH_VAR_NAME_:
+	.asciz	"windowWillResize:toSize:"
+
+	.section	__TEXT,__objc_methtype,cstring_literals
+L_OBJC_METH_VAR_TYPE_:
+	.asciz	"{CGSize=dd}40@0:8@16{CGSize=dd}24"
+
+	.section	__TEXT,__objc_methname,cstring_literals
+L_OBJC_METH_VAR_NAME_.2:
+	.asciz	".cxx_destruct"
+
+	.section	__TEXT,__objc_methtype,cstring_literals
+L_OBJC_METH_VAR_TYPE_.3:
+	.asciz	"v16@0:8"
+
+	.section	__DATA,__objc_const
+	.p2align	3, 0x0
+__OBJC_$_INSTANCE_METHODS_MACHWindowDelegate:
+	.long	24
+	.long	2
+	.quad	L_OBJC_METH_VAR_NAME_
+	.quad	L_OBJC_METH_VAR_TYPE_
+	.quad	"-[MACHWindowDelegate windowWillResize:toSize:]"
+	.quad	L_OBJC_METH_VAR_NAME_.2
+	.quad	L_OBJC_METH_VAR_TYPE_.3
+	.quad	"-[MACHWindowDelegate .cxx_destruct]"
+
+	.private_extern	_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block
+	.section	__DATA,__objc_ivar
+	.globl	_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block
+	.p2align	3, 0x0
+_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block:
+	.quad	8
+
+	.section	__TEXT,__objc_methname,cstring_literals
+L_OBJC_METH_VAR_NAME_.4:
+	.asciz	"_windowWillResize_toSize_block"
+
+	.section	__TEXT,__objc_methtype,cstring_literals
+L_OBJC_METH_VAR_TYPE_.5:
+	.asciz	"@?"
+
+	.section	__DATA,__objc_const
+	.p2align	3, 0x0
+__OBJC_$_INSTANCE_VARIABLES_MACHWindowDelegate:
+	.long	32
+	.long	1
+	.quad	_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block
+	.quad	L_OBJC_METH_VAR_NAME_.4
+	.quad	L_OBJC_METH_VAR_TYPE_.5
+	.long	3
+	.long	8
+
+	.p2align	3, 0x0
+__OBJC_CLASS_RO_$_MACHWindowDelegate:
+	.long	388
+	.long	8
+	.long	16
+	.space	4
+	.quad	L_OBJC_CLASS_NAME_.1
+	.quad	L_OBJC_CLASS_NAME_
+	.quad	__OBJC_$_INSTANCE_METHODS_MACHWindowDelegate
+	.quad	0
+	.quad	__OBJC_$_INSTANCE_VARIABLES_MACHWindowDelegate
+	.quad	0
+	.quad	0
+
+	.section	__DATA,__objc_data
+	.globl	_OBJC_CLASS_$_MACHWindowDelegate
+	.p2align	3, 0x0
+_OBJC_CLASS_$_MACHWindowDelegate:
+	.quad	_OBJC_METACLASS_$_MACHWindowDelegate
+	.quad	_OBJC_CLASS_$_NSObject
+	.quad	__objc_empty_cache
+	.quad	0
+	.quad	__OBJC_CLASS_RO_$_MACHWindowDelegate
+
+	.section	__DATA,__objc_classlist,regular,no_dead_strip
+	.p2align	3, 0x0
+l_OBJC_LABEL_CLASS_$:
+	.quad	_OBJC_CLASS_$_MACHWindowDelegate
+
+	.section	__DATA,__objc_imageinfo,regular,no_dead_strip
+L_OBJC_IMAGE_INFO:
+	.long	0
+	.long	64
+
+.subsections_via_symbols

--- a/generator.zig
+++ b/generator.zig
@@ -1911,14 +1911,27 @@ fn generateAppKit(generator: anytype) !void {
         [2][]const u8{ "NSWindow", "isVisible" },
         [2][]const u8{ "NSWindow", "setIsVisible" },
         [2][]const u8{ "NSWindow", "makeKeyAndOrderFront" },
+        //[2][]const u8{ "NSWindow", "setDelegate" },
+        [2][]const u8{ "NSWindow", "title" },
+        [2][]const u8{ "NSWindow", "setTitle" },
+
+        [2][]const u8{ "NSWindow", "update" },
+        [2][]const u8{ "NSWindow", "setMinSize" },
+
+        //[2][]const u8{ "NSWindowDelegate", "windowWillResize:toSize" },
 
         [2][]const u8{ "NSView", "layer" },
         [2][]const u8{ "NSView", "setLayer" },
 
         [2][]const u8{ "NSResponder", "" },
 
+        //[2][]const u8{ "NSCoder", "" },
+        //[2][]const u8{ "NSDictionary", "" },
+
         [2][]const u8{ "NSScreen", "screens" },
         [2][]const u8{ "NSScreen", "mainScreen" },
+        [2][]const u8{ "NSScreen", "frame" },
+        [2][]const u8{ "NSScreen", "visibleFrame" },
 
         [2][]const u8{ "NSApplicationDelegate", "applicationDidFinishLaunching" },
 
@@ -2150,6 +2163,7 @@ fn generateAppKit(generator: anytype) !void {
     // // try generator.addEnum("NSLinguisticTagScheme");
 
     try generator.addProtocol("NSApplicationDelegate");
+    try generator.addProtocol("NSWindowDelegate");
     // try generator.addProtocol("NSUserActivityRestoring");
     // try generator.addProtocol("NSSecureCoding");
     // try generator.addProtocol("NSCopying");

--- a/generator.zig
+++ b/generator.zig
@@ -1911,14 +1911,19 @@ fn generateAppKit(generator: anytype) !void {
         [2][]const u8{ "NSWindow", "isVisible" },
         [2][]const u8{ "NSWindow", "setIsVisible" },
         [2][]const u8{ "NSWindow", "makeKeyAndOrderFront" },
-        //[2][]const u8{ "NSWindow", "setDelegate" },
+        [2][]const u8{ "NSWindow", "setDelegate" },
         [2][]const u8{ "NSWindow", "title" },
         [2][]const u8{ "NSWindow", "setTitle" },
+        [2][]const u8{ "NSWindow", "contentRectForFrameRect" },
+        [2][]const u8{ "NSWindow", "frameRectForContentRect" },
+        [2][]const u8{ "NSWindow", "frame" },
+        [2][]const u8{ "NSWindow", "setFrame:display:animate" },
+        [2][]const u8{ "NSWindow", "toggleFullscreen" },
 
         [2][]const u8{ "NSWindow", "update" },
         [2][]const u8{ "NSWindow", "setMinSize" },
 
-        //[2][]const u8{ "NSWindowDelegate", "windowWillResize:toSize" },
+        [2][]const u8{ "NSWindowDelegate", "windowWillResize:toSize" },
 
         [2][]const u8{ "NSView", "layer" },
         [2][]const u8{ "NSView", "setLayer" },

--- a/src/app_kit.zig
+++ b/src/app_kit.zig
@@ -119,8 +119,17 @@ pub const Window = opaque {
     pub fn initWithContentRect_styleMask_backing_defer_screen(self_: *@This(), contentRect_: Rect, style_: WindowStyleMask, backingStoreType_: BackingStoreType, flag_: bool, screen_: ?*Screen) *@This() {
         return objc.msgSend(self_, "initWithContentRect:styleMask:backing:defer:screen:", *@This(), .{ contentRect_, style_, backingStoreType_, flag_, screen_ });
     }
+    pub fn update(self_: *@This()) void {
+        return objc.msgSend(self_, "update", void, .{});
+    }
     pub fn makeKeyAndOrderFront(self_: *@This(), sender_: ?*objc.Id) void {
         return objc.msgSend(self_, "makeKeyAndOrderFront:", void, .{sender_});
+    }
+    pub fn title(self_: *@This()) *String {
+        return objc.msgSend(self_, "title", *String, .{});
+    }
+    pub fn setTitle(self_: *@This(), title_: *String) void {
+        return objc.msgSend(self_, "setTitle:", void, .{title_});
     }
     pub fn contentView(self_: *@This()) ?*View {
         return objc.msgSend(self_, "contentView", ?*View, .{});
@@ -133,6 +142,9 @@ pub const Window = opaque {
     }
     pub fn isVisible(self_: *@This()) bool {
         return objc.msgSend(self_, "isVisible", bool, .{});
+    }
+    pub fn setMinSize(self_: *@This(), minSize_: Size) void {
+        return objc.msgSend(self_, "setMinSize:", void, .{minSize_});
     }
     pub fn setIsVisible(self_: *@This(), flag_: bool) void {
         return objc.msgSend(self_, "setIsVisible:", void, .{flag_});
@@ -205,6 +217,12 @@ pub const Screen = opaque {
     }
     pub fn mainScreen() ?*Screen {
         return objc.msgSend(@This().InternalInfo.class(), "mainScreen", ?*Screen, .{});
+    }
+    pub fn frame(self_: *@This()) Rect {
+        return objc.msgSend(self_, "frame", Rect, .{});
+    }
+    pub fn visibleFrame(self_: *@This()) Rect {
+        return objc.msgSend(self_, "visibleFrame", Rect, .{});
     }
 };
 

--- a/src/app_kit.zig
+++ b/src/app_kit.zig
@@ -116,8 +116,17 @@ pub const Window = opaque {
     pub const alloc = InternalInfo.alloc;
     pub const allocInit = InternalInfo.allocInit;
 
+    pub fn frameRectForContentRect(self_: *@This(), contentRect_: Rect) Rect {
+        return objc.msgSend(self_, "frameRectForContentRect:", Rect, .{contentRect_});
+    }
+    pub fn contentRectForFrameRect(self_: *@This(), frameRect_: Rect) Rect {
+        return objc.msgSend(self_, "contentRectForFrameRect:", Rect, .{frameRect_});
+    }
     pub fn initWithContentRect_styleMask_backing_defer_screen(self_: *@This(), contentRect_: Rect, style_: WindowStyleMask, backingStoreType_: BackingStoreType, flag_: bool, screen_: ?*Screen) *@This() {
         return objc.msgSend(self_, "initWithContentRect:styleMask:backing:defer:screen:", *@This(), .{ contentRect_, style_, backingStoreType_, flag_, screen_ });
+    }
+    pub fn setFrame_display_animate(self_: *@This(), frameRect_: Rect, displayFlag_: bool, animateFlag_: bool) void {
+        return objc.msgSend(self_, "setFrame:display:animate:", void, .{ frameRect_, displayFlag_, animateFlag_ });
     }
     pub fn update(self_: *@This()) void {
         return objc.msgSend(self_, "update", void, .{});
@@ -133,6 +142,12 @@ pub const Window = opaque {
     }
     pub fn contentView(self_: *@This()) ?*View {
         return objc.msgSend(self_, "contentView", ?*View, .{});
+    }
+    pub fn setDelegate(self_: *@This(), delegate_: ?*WindowDelegate) void {
+        return objc.msgSend(self_, "setDelegate:", void, .{delegate_});
+    }
+    pub fn frame(self_: *@This()) Rect {
+        return objc.msgSend(self_, "frame", Rect, .{});
     }
     pub fn isReleasedWhenClosed(self_: *@This()) bool {
         return objc.msgSend(self_, "isReleasedWhenClosed", bool, .{});
@@ -235,6 +250,18 @@ pub const ApplicationDelegate = opaque {
 
     pub fn applicationDidFinishLaunching(self_: *@This(), notification_: *Notification) void {
         return objc.msgSend(self_, "applicationDidFinishLaunching:", void, .{notification_});
+    }
+};
+
+pub const WindowDelegate = opaque {
+    pub const InternalInfo = objc.ExternProtocol(@This(), &.{ ObjectProtocol, ObjectProtocol });
+    pub const as = InternalInfo.as;
+    pub const retain = InternalInfo.retain;
+    pub const release = InternalInfo.release;
+    pub const autorelease = InternalInfo.autorelease;
+
+    pub fn windowWillResize_toSize(self_: *@This(), sender_: *Window, frameSize_: Size) Size {
+        return objc.msgSend(self_, "windowWillResize:toSize:", Size, .{ sender_, frameSize_ });
     }
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,7 +11,7 @@ pub const app_kit = @import("app_kit.zig");
 
 pub const mach = struct {
     pub const AppDelegate = opaque {
-        pub const InternalInfo = objc.ExternClass("MACHAppDelegate", @This(), foundation.ObjectInterface, &.{app_kit.ApplicationDelegate});
+        pub const InternalInfo = objc.ExternClass("MACHAppDelegate", AppDelegate, foundation.ObjectInterface, &.{app_kit.ApplicationDelegate});
         pub const as = InternalInfo.as;
         pub const retain = InternalInfo.retain;
         pub const release = InternalInfo.release;
@@ -26,6 +26,25 @@ pub const mach = struct {
         const method = @extern(
             *const fn (*AppDelegate, *foundation.Block(fn () void)) callconv(.C) void,
             .{ .name = "\x01-[MACHAppDelegate setRunBlock:]" },
+        );
+    };
+
+    pub const WindowDelegate = opaque {
+        pub const InternalInfo = objc.ExternClass("MACHWindowDelegate", WindowDelegate, foundation.ObjectInterface, &.{app_kit.WindowDelegate});
+        pub const as = InternalInfo.as;
+        pub const retain = InternalInfo.retain;
+        pub const release = InternalInfo.release;
+        pub const autorelease = InternalInfo.autorelease;
+        pub const new = InternalInfo.new;
+        pub const alloc = InternalInfo.alloc;
+        pub const allocInit = InternalInfo.allocInit;
+
+        pub fn setBlock_windowWillResize_toSize(self: *WindowDelegate, block: *foundation.Block(fn (core_graphics.Size) void)) void {
+            method_windowWillResize_toSize(self, block);
+        }
+        const method_windowWillResize_toSize = @extern(
+            *const fn (*WindowDelegate, *foundation.Block(fn (core_graphics.Size) void)) callconv(.C) void,
+            .{ .name = "\x01-[MACHWindowDelegate setBlock_windowWillResize_toSize:]" },
         );
     };
 };


### PR DESCRIPTION
~~For now this draft PR just adds the functions necessary to get the window title showing and updating. I plan on continuing to add additional functions as needed to improve windowing on macOS.~~

This PR currently adds additional methods to `generator.zig` to allow implementation in [this companion PR](https://github.com/hexops/mach/pull/1299)

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.