### PR TITLE
`windowWillResize_toSize` -> `windowDidResize`

### DIFF
--- a/MACHWindowDelegate.m
+++ b/MACHWindowDelegate.m
@@ -5,25 +5,28 @@
 @end
 
 @implementation MACHWindowDelegate {
-    void (^_windowWillResize_toSize_block)(NSSize);
+    void (^_windowDidResize_block)(void);
     bool (^_windowShouldClose_block)(void);
 }
 
-- (void)setBlock_windowWillResize_toSize:(void (^)(NSSize))windowWillResize_toSize_block __attribute__((objc_direct)) {
-    _windowWillResize_toSize_block = windowWillResize_toSize_block;
+- (void)setBlock_windowDidResize:(void (^)(void))windowDidResize_block __attribute__((objc_direct)) {
+    _windowDidResize_block = windowDidResize_block;
 }
 
 - (void)setBlock_windowShouldClose:(bool (^)(void))windowShouldClose_block __attribute__((objc_direct)) {
     _windowShouldClose_block = windowShouldClose_block;
 }
 
-- (NSSize)windowWillResize:(NSWindow *)sender toSize:(NSSize)frameSize {
-    if (self->_windowWillResize_toSize_block) self->_windowWillResize_toSize_block(frameSize);
-    return frameSize;
+- (void) windowDidResize:(NSNotification *) notification {
+    if (self->_windowDidResize_block) self->_windowDidResize_block();
 }
 
 - (BOOL)windowShouldClose:(NSWindow *)sender {
     if (self->_windowShouldClose_block) self->_windowShouldClose_block();
     return NO;
+}
+
+- (void)windowWillClose:(NSNotification *)notification {
+    //NSLog(@"windowWillClose");
 }
 @end

--- a/MACHWindowDelegate_arm64_apple_macos12.s
+++ b/MACHWindowDelegate_arm64_apple_macos12.s
@@ -1,9 +1,9 @@
 	.section	__TEXT,__text,regular,pure_instructions
 	.build_version macos, 12, 0
-	.private_extern	"-[MACHWindowDelegate setBlock_windowWillResize_toSize:]"
-	.globl	"-[MACHWindowDelegate setBlock_windowWillResize_toSize:]"
+	.private_extern	"-[MACHWindowDelegate setBlock_windowDidResize:]"
+	.globl	"-[MACHWindowDelegate setBlock_windowDidResize:]"
 	.p2align	2
-"-[MACHWindowDelegate setBlock_windowWillResize_toSize:]":
+"-[MACHWindowDelegate setBlock_windowDidResize:]":
 	.cfi_startproc
 	cbz	x0, LBB0_2
 	stp	x20, x19, [sp, #-32]!
@@ -55,28 +55,13 @@ LBB1_2:
 	.cfi_endproc
 
 	.p2align	2
-"-[MACHWindowDelegate windowWillResize:toSize:]":
+"-[MACHWindowDelegate windowDidResize:]":
 	.cfi_startproc
-	stp	d9, d8, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
-	.cfi_def_cfa_offset 32
-	.cfi_offset w30, -8
-	.cfi_offset w29, -16
-	.cfi_offset b8, -24
-	.cfi_offset b9, -32
-	fmov	d8, d1
-	fmov	d9, d0
 	ldr	x0, [x0, #8]
 	cbz	x0, LBB2_2
-	fmov	d0, d9
-	fmov	d1, d8
-	ldr	x8, [x0, #16]
-	blr	x8
+	ldr	x1, [x0, #16]
+	br	x1
 LBB2_2:
-	ldp	x29, x30, [sp, #16]
-	fmov	d0, d9
-	fmov	d1, d8
-	ldp	d9, d8, [sp], #32
 	ret
 	.cfi_endproc
 
@@ -94,6 +79,12 @@ LBB2_2:
 	ldp	x29, x30, [sp], #16
 LBB3_2:
 	mov	w0, wzr
+	ret
+	.cfi_endproc
+
+	.p2align	2
+"-[MACHWindowDelegate windowWillClose:]":
+	.cfi_startproc
 	ret
 	.cfi_endproc
 
@@ -153,11 +144,11 @@ l_OBJC_CLASS_NAME_.1:
 
 	.section	__TEXT,__objc_methname,cstring_literals
 l_OBJC_METH_VAR_NAME_:
-	.asciz	"windowWillResize:toSize:"
+	.asciz	"windowDidResize:"
 
 	.section	__TEXT,__objc_methtype,cstring_literals
 l_OBJC_METH_VAR_TYPE_:
-	.asciz	"{CGSize=dd}40@0:8@16{CGSize=dd}24"
+	.asciz	"v24@0:8@16"
 
 	.section	__TEXT,__objc_methname,cstring_literals
 l_OBJC_METH_VAR_NAME_.2:
@@ -169,40 +160,46 @@ l_OBJC_METH_VAR_TYPE_.3:
 
 	.section	__TEXT,__objc_methname,cstring_literals
 l_OBJC_METH_VAR_NAME_.4:
+	.asciz	"windowWillClose:"
+
+l_OBJC_METH_VAR_NAME_.5:
 	.asciz	".cxx_destruct"
 
 	.section	__TEXT,__objc_methtype,cstring_literals
-l_OBJC_METH_VAR_TYPE_.5:
+l_OBJC_METH_VAR_TYPE_.6:
 	.asciz	"v16@0:8"
 
 	.section	__DATA,__objc_const
 	.p2align	3, 0x0
 __OBJC_$_INSTANCE_METHODS_MACHWindowDelegate:
 	.long	24
-	.long	3
+	.long	4
 	.quad	l_OBJC_METH_VAR_NAME_
 	.quad	l_OBJC_METH_VAR_TYPE_
-	.quad	"-[MACHWindowDelegate windowWillResize:toSize:]"
+	.quad	"-[MACHWindowDelegate windowDidResize:]"
 	.quad	l_OBJC_METH_VAR_NAME_.2
 	.quad	l_OBJC_METH_VAR_TYPE_.3
 	.quad	"-[MACHWindowDelegate windowShouldClose:]"
 	.quad	l_OBJC_METH_VAR_NAME_.4
-	.quad	l_OBJC_METH_VAR_TYPE_.5
+	.quad	l_OBJC_METH_VAR_TYPE_
+	.quad	"-[MACHWindowDelegate windowWillClose:]"
+	.quad	l_OBJC_METH_VAR_NAME_.5
+	.quad	l_OBJC_METH_VAR_TYPE_.6
 	.quad	"-[MACHWindowDelegate .cxx_destruct]"
 
-	.private_extern	_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block
+	.private_extern	_OBJC_IVAR_$_MACHWindowDelegate._windowDidResize_block
 	.section	__DATA,__objc_ivar
-	.globl	_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block
+	.globl	_OBJC_IVAR_$_MACHWindowDelegate._windowDidResize_block
 	.p2align	2, 0x0
-_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block:
+_OBJC_IVAR_$_MACHWindowDelegate._windowDidResize_block:
 	.long	8
 
 	.section	__TEXT,__objc_methname,cstring_literals
-l_OBJC_METH_VAR_NAME_.6:
-	.asciz	"_windowWillResize_toSize_block"
+l_OBJC_METH_VAR_NAME_.7:
+	.asciz	"_windowDidResize_block"
 
 	.section	__TEXT,__objc_methtype,cstring_literals
-l_OBJC_METH_VAR_TYPE_.7:
+l_OBJC_METH_VAR_TYPE_.8:
 	.asciz	"@?"
 
 	.private_extern	_OBJC_IVAR_$_MACHWindowDelegate._windowShouldClose_block
@@ -213,7 +210,7 @@ _OBJC_IVAR_$_MACHWindowDelegate._windowShouldClose_block:
 	.long	16
 
 	.section	__TEXT,__objc_methname,cstring_literals
-l_OBJC_METH_VAR_NAME_.8:
+l_OBJC_METH_VAR_NAME_.9:
 	.asciz	"_windowShouldClose_block"
 
 	.section	__DATA,__objc_const
@@ -221,14 +218,14 @@ l_OBJC_METH_VAR_NAME_.8:
 __OBJC_$_INSTANCE_VARIABLES_MACHWindowDelegate:
 	.long	32
 	.long	2
-	.quad	_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block
-	.quad	l_OBJC_METH_VAR_NAME_.6
-	.quad	l_OBJC_METH_VAR_TYPE_.7
+	.quad	_OBJC_IVAR_$_MACHWindowDelegate._windowDidResize_block
+	.quad	l_OBJC_METH_VAR_NAME_.7
+	.quad	l_OBJC_METH_VAR_TYPE_.8
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHWindowDelegate._windowShouldClose_block
-	.quad	l_OBJC_METH_VAR_NAME_.8
-	.quad	l_OBJC_METH_VAR_TYPE_.7
+	.quad	l_OBJC_METH_VAR_NAME_.9
+	.quad	l_OBJC_METH_VAR_TYPE_.8
 	.long	3
 	.long	8
 

--- a/MACHWindowDelegate_x86_64_apple_macos12.s
+++ b/MACHWindowDelegate_x86_64_apple_macos12.s
@@ -1,8 +1,8 @@
 	.section	__TEXT,__text,regular,pure_instructions
 	.build_version macos, 12, 0
-	.private_extern	"-[MACHWindowDelegate setBlock_windowWillResize_toSize:]"
-	.globl	"-[MACHWindowDelegate setBlock_windowWillResize_toSize:]"
-"-[MACHWindowDelegate setBlock_windowWillResize_toSize:]":
+	.private_extern	"-[MACHWindowDelegate setBlock_windowDidResize:]"
+	.globl	"-[MACHWindowDelegate setBlock_windowDidResize:]"
+"-[MACHWindowDelegate setBlock_windowDidResize:]":
 	.cfi_startproc
 	pushq	%rbx
 	.cfi_def_cfa_offset 16
@@ -42,27 +42,14 @@ LBB1_1:
 	retq
 	.cfi_endproc
 
-"-[MACHWindowDelegate windowWillResize:toSize:]":
+"-[MACHWindowDelegate windowDidResize:]":
 
 	.cfi_startproc
 	movq	8(%rdi), %rdi
 	testq	%rdi, %rdi
-	je	LBB2_2
-	subq	$24, %rsp
-	.cfi_def_cfa_offset 32
-	movsd	%xmm0, 8(%rsp)
-	movsd	8(%rsp), %xmm0
-
-	movsd	%xmm1, 16(%rsp)
-	movsd	16(%rsp), %xmm1
-
-	callq	*16(%rdi)
-	movsd	8(%rsp), %xmm0
-
-	movsd	16(%rsp), %xmm1
-
-	addq	$24, %rsp
-LBB2_2:
+	je	LBB2_1
+	jmpq	*16(%rdi)
+LBB2_1:
 	retq
 	.cfi_endproc
 
@@ -78,6 +65,12 @@ LBB2_2:
 	addq	$8, %rsp
 LBB3_2:
 	xorl	%eax, %eax
+	retq
+	.cfi_endproc
+
+"-[MACHWindowDelegate windowWillClose:]":
+
+	.cfi_startproc
 	retq
 	.cfi_endproc
 
@@ -133,11 +126,11 @@ L_OBJC_CLASS_NAME_.1:
 
 	.section	__TEXT,__objc_methname,cstring_literals
 L_OBJC_METH_VAR_NAME_:
-	.asciz	"windowWillResize:toSize:"
+	.asciz	"windowDidResize:"
 
 	.section	__TEXT,__objc_methtype,cstring_literals
 L_OBJC_METH_VAR_TYPE_:
-	.asciz	"{CGSize=dd}40@0:8@16{CGSize=dd}24"
+	.asciz	"v24@0:8@16"
 
 	.section	__TEXT,__objc_methname,cstring_literals
 L_OBJC_METH_VAR_NAME_.2:
@@ -149,40 +142,46 @@ L_OBJC_METH_VAR_TYPE_.3:
 
 	.section	__TEXT,__objc_methname,cstring_literals
 L_OBJC_METH_VAR_NAME_.4:
+	.asciz	"windowWillClose:"
+
+L_OBJC_METH_VAR_NAME_.5:
 	.asciz	".cxx_destruct"
 
 	.section	__TEXT,__objc_methtype,cstring_literals
-L_OBJC_METH_VAR_TYPE_.5:
+L_OBJC_METH_VAR_TYPE_.6:
 	.asciz	"v16@0:8"
 
 	.section	__DATA,__objc_const
 	.p2align	3, 0x0
 __OBJC_$_INSTANCE_METHODS_MACHWindowDelegate:
 	.long	24
-	.long	3
+	.long	4
 	.quad	L_OBJC_METH_VAR_NAME_
 	.quad	L_OBJC_METH_VAR_TYPE_
-	.quad	"-[MACHWindowDelegate windowWillResize:toSize:]"
+	.quad	"-[MACHWindowDelegate windowDidResize:]"
 	.quad	L_OBJC_METH_VAR_NAME_.2
 	.quad	L_OBJC_METH_VAR_TYPE_.3
 	.quad	"-[MACHWindowDelegate windowShouldClose:]"
 	.quad	L_OBJC_METH_VAR_NAME_.4
-	.quad	L_OBJC_METH_VAR_TYPE_.5
+	.quad	L_OBJC_METH_VAR_TYPE_
+	.quad	"-[MACHWindowDelegate windowWillClose:]"
+	.quad	L_OBJC_METH_VAR_NAME_.5
+	.quad	L_OBJC_METH_VAR_TYPE_.6
 	.quad	"-[MACHWindowDelegate .cxx_destruct]"
 
-	.private_extern	_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block
+	.private_extern	_OBJC_IVAR_$_MACHWindowDelegate._windowDidResize_block
 	.section	__DATA,__objc_ivar
-	.globl	_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block
+	.globl	_OBJC_IVAR_$_MACHWindowDelegate._windowDidResize_block
 	.p2align	3, 0x0
-_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block:
+_OBJC_IVAR_$_MACHWindowDelegate._windowDidResize_block:
 	.quad	8
 
 	.section	__TEXT,__objc_methname,cstring_literals
-L_OBJC_METH_VAR_NAME_.6:
-	.asciz	"_windowWillResize_toSize_block"
+L_OBJC_METH_VAR_NAME_.7:
+	.asciz	"_windowDidResize_block"
 
 	.section	__TEXT,__objc_methtype,cstring_literals
-L_OBJC_METH_VAR_TYPE_.7:
+L_OBJC_METH_VAR_TYPE_.8:
 	.asciz	"@?"
 
 	.private_extern	_OBJC_IVAR_$_MACHWindowDelegate._windowShouldClose_block
@@ -193,7 +192,7 @@ _OBJC_IVAR_$_MACHWindowDelegate._windowShouldClose_block:
 	.quad	16
 
 	.section	__TEXT,__objc_methname,cstring_literals
-L_OBJC_METH_VAR_NAME_.8:
+L_OBJC_METH_VAR_NAME_.9:
 	.asciz	"_windowShouldClose_block"
 
 	.section	__DATA,__objc_const
@@ -201,14 +200,14 @@ L_OBJC_METH_VAR_NAME_.8:
 __OBJC_$_INSTANCE_VARIABLES_MACHWindowDelegate:
 	.long	32
 	.long	2
-	.quad	_OBJC_IVAR_$_MACHWindowDelegate._windowWillResize_toSize_block
-	.quad	L_OBJC_METH_VAR_NAME_.6
-	.quad	L_OBJC_METH_VAR_TYPE_.7
+	.quad	_OBJC_IVAR_$_MACHWindowDelegate._windowDidResize_block
+	.quad	L_OBJC_METH_VAR_NAME_.7
+	.quad	L_OBJC_METH_VAR_TYPE_.8
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHWindowDelegate._windowShouldClose_block
-	.quad	L_OBJC_METH_VAR_NAME_.8
-	.quad	L_OBJC_METH_VAR_TYPE_.7
+	.quad	L_OBJC_METH_VAR_NAME_.9
+	.quad	L_OBJC_METH_VAR_TYPE_.8
 	.long	3
 	.long	8
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -39,12 +39,12 @@ pub const mach = struct {
         pub const alloc = InternalInfo.alloc;
         pub const allocInit = InternalInfo.allocInit;
 
-        pub fn setBlock_windowWillResize_toSize(self: *WindowDelegate, block: *foundation.Block(fn (core_graphics.Size) void)) void {
-            method_windowWillResize_toSize(self, block);
+        pub fn setBlock_windowDidResize(self: *WindowDelegate, block: *foundation.Block(fn () void)) void {
+            method_windowDidResize(self, block);
         }
-        const method_windowWillResize_toSize = @extern(
-            *const fn (*WindowDelegate, *foundation.Block(fn (core_graphics.Size) void)) callconv(.C) void,
-            .{ .name = "\x01-[MACHWindowDelegate setBlock_windowWillResize_toSize:]" },
+        const method_windowDidResize = @extern(
+            *const fn (*WindowDelegate, *foundation.Block(fn () void)) callconv(.C) void,
+            .{ .name = "\x01-[MACHWindowDelegate setBlock_windowDidResize:]" },
         );
 
         pub fn setBlock_windowShouldClose(self: *WindowDelegate, block: *foundation.Block(fn () bool)) void {
@@ -66,10 +66,10 @@ pub const mach = struct {
         pub const alloc = InternalInfo.alloc;
         pub const allocInit = InternalInfo.allocInit;
 
-        pub fn layer(self_: *@This()) *quartz_core.Layer {
-            return objc.msgSend(self_, "layer", *quartz_core.Layer, .{});
+        pub fn layer(self_: *@This()) *quartz_core.MetalLayer {
+            return objc.msgSend(self_, "layer", *quartz_core.MetalLayer, .{});
         }
-        pub fn setLayer(self_: *@This(), layer_: *quartz_core.Layer) void {
+        pub fn setLayer(self_: *@This(), layer_: *quartz_core.MetalLayer) void {
             return objc.msgSend(self_, "setLayer:", void, .{layer_});
         }
 

--- a/src/quartz_core.zig
+++ b/src/quartz_core.zig
@@ -18,6 +18,10 @@ pub const MetalDrawable = opaque {
     pub const release = InternalInfo.release;
     pub const autorelease = InternalInfo.autorelease;
 
+    pub fn present(self_: *@This()) void {
+        return objc.msgSend(self_, "present", void, .{});
+    }
+
     pub fn texture(self_: *@This()) *mtl.Texture {
         return objc.msgSend(self_, "texture", *mtl.Texture, .{});
     }
@@ -88,7 +92,7 @@ pub const MetalLayer = opaque {
         return objc.msgSend(self_, "setOpaque:", void, .{opaque_});
     }
     pub fn setOpacity(self_: *@This(), opacity_: f32) void {
-        return objc.msgSend(self_, "setOpaque:", void, .{opacity_});
+        return objc.msgSend(self_, "setOpacity:", void, .{opacity_});
     }
     pub fn wantsExtendedDynamicRangeContent(self_: *@This()) bool {
         return objc.msgSend(self_, "wantsExtendedDynamicRangeContent", bool, .{});


### PR DESCRIPTION

This PR is necessary for https://github.com/hexops/mach/pull/1317 and needs to be merged first so that the `build.zig.zon` can be updated. 

After more research, I found that `windowDidResize` is the better way to get the window size change, as we need to get the frame and use `ContentRectForFrameRect` to make sure we are getting the correct window size with respect to the titlebar. This fixes an issue where resizing the window with the mouse, and then programmatically setting the window size would yield an incorrect window size.

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.