### PR TITLE
View: add override to remove default macos keybinds from interfering

### DIFF
--- a/MACHAppDelegate_arm64_apple_macos12.s
+++ b/MACHAppDelegate_arm64_apple_macos12.s
@@ -7,8 +7,8 @@
 	.cfi_startproc
 	cbz	x0, LBB0_2
 	stp	x20, x19, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
 	.cfi_def_cfa_offset 32
+	stp	x29, x30, [sp, #16]
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
@@ -17,11 +17,15 @@
 	mov	x0, x1
 	bl	_objc_retainBlock
 	ldr	x8, [x19, #8]
-	ldp	x29, x30, [sp, #16]
-	mov	x9, x0
+	str	x0, [x19, #8]
 	mov	x0, x8
-	str	x9, [x19, #8]
+	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
 	b	_objc_release
 LBB0_2:
 	ret
@@ -41,7 +45,7 @@ LBB1_2:
 	.p2align	2
 "-[MACHAppDelegate applicationShouldTerminate:]":
 	.cfi_startproc
-	mov	x0, xzr
+	mov	x0, #0
 	ret
 	.cfi_endproc
 
@@ -56,7 +60,7 @@ LBB1_2:
 "-[MACHAppDelegate .cxx_destruct]":
 	.cfi_startproc
 	add	x0, x0, #8
-	mov	x1, xzr
+	mov	x1, #0
 	b	_objc_storeStrong
 	.cfi_endproc
 

--- a/MACHView.m
+++ b/MACHView.m
@@ -176,6 +176,12 @@
     _magnify_block(event);
 }
 
+// Add this method to prevent default macos keybind operations
+// such as escape pulling the window out of fullscreen
+- (void)doCommandBySelector:(SEL)selector
+{
+}
+
 // This overrides the default initializer and creates a tracking area over the
 // views visible rect
 - (id)initWithFrame:(NSRect)frame {

--- a/MACHView_arm64_apple_macos12.s
+++ b/MACHView_arm64_apple_macos12.s
@@ -21,8 +21,8 @@
 	.cfi_startproc
 	cbz	x0, LBB2_2
 	stp	x20, x19, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
 	.cfi_def_cfa_offset 32
+	stp	x29, x30, [sp, #16]
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
@@ -32,14 +32,18 @@
 	bl	_objc_retainBlock
 Lloh0:
 	adrp	x8, _OBJC_IVAR_$_MACHView._keyDown_block@PAGE
-	ldp	x29, x30, [sp, #16]
 Lloh1:
-	ldrsw	x10, [x8, _OBJC_IVAR_$_MACHView._keyDown_block@PAGEOFF]
-	mov	x9, x0
-	ldr	x8, [x19, x10]
-	str	x9, [x19, x10]
+	ldrsw	x9, [x8, _OBJC_IVAR_$_MACHView._keyDown_block@PAGEOFF]
+	ldr	x8, [x19, x9]
+	str	x0, [x19, x9]
 	mov	x0, x8
+	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
 	b	_objc_release
 LBB2_2:
 	ret
@@ -53,8 +57,8 @@ LBB2_2:
 	.cfi_startproc
 	cbz	x0, LBB3_2
 	stp	x20, x19, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
 	.cfi_def_cfa_offset 32
+	stp	x29, x30, [sp, #16]
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
@@ -64,14 +68,18 @@ LBB2_2:
 	bl	_objc_retainBlock
 Lloh2:
 	adrp	x8, _OBJC_IVAR_$_MACHView._keyUp_block@PAGE
-	ldp	x29, x30, [sp, #16]
 Lloh3:
-	ldrsw	x10, [x8, _OBJC_IVAR_$_MACHView._keyUp_block@PAGEOFF]
-	mov	x9, x0
-	ldr	x8, [x19, x10]
-	str	x9, [x19, x10]
+	ldrsw	x9, [x8, _OBJC_IVAR_$_MACHView._keyUp_block@PAGEOFF]
+	ldr	x8, [x19, x9]
+	str	x0, [x19, x9]
 	mov	x0, x8
+	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
 	b	_objc_release
 LBB3_2:
 	ret
@@ -85,8 +93,8 @@ LBB3_2:
 	.cfi_startproc
 	cbz	x0, LBB4_2
 	stp	x20, x19, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
 	.cfi_def_cfa_offset 32
+	stp	x29, x30, [sp, #16]
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
@@ -96,14 +104,18 @@ LBB3_2:
 	bl	_objc_retainBlock
 Lloh4:
 	adrp	x8, _OBJC_IVAR_$_MACHView._mouseMoved_block@PAGE
-	ldp	x29, x30, [sp, #16]
 Lloh5:
-	ldrsw	x10, [x8, _OBJC_IVAR_$_MACHView._mouseMoved_block@PAGEOFF]
-	mov	x9, x0
-	ldr	x8, [x19, x10]
-	str	x9, [x19, x10]
+	ldrsw	x9, [x8, _OBJC_IVAR_$_MACHView._mouseMoved_block@PAGEOFF]
+	ldr	x8, [x19, x9]
+	str	x0, [x19, x9]
 	mov	x0, x8
+	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
 	b	_objc_release
 LBB4_2:
 	ret
@@ -117,8 +129,8 @@ LBB4_2:
 	.cfi_startproc
 	cbz	x0, LBB5_2
 	stp	x20, x19, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
 	.cfi_def_cfa_offset 32
+	stp	x29, x30, [sp, #16]
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
@@ -128,14 +140,18 @@ LBB4_2:
 	bl	_objc_retainBlock
 Lloh6:
 	adrp	x8, _OBJC_IVAR_$_MACHView._mouseDown_block@PAGE
-	ldp	x29, x30, [sp, #16]
 Lloh7:
-	ldrsw	x10, [x8, _OBJC_IVAR_$_MACHView._mouseDown_block@PAGEOFF]
-	mov	x9, x0
-	ldr	x8, [x19, x10]
-	str	x9, [x19, x10]
+	ldrsw	x9, [x8, _OBJC_IVAR_$_MACHView._mouseDown_block@PAGEOFF]
+	ldr	x8, [x19, x9]
+	str	x0, [x19, x9]
 	mov	x0, x8
+	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
 	b	_objc_release
 LBB5_2:
 	ret
@@ -149,8 +165,8 @@ LBB5_2:
 	.cfi_startproc
 	cbz	x0, LBB6_2
 	stp	x20, x19, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
 	.cfi_def_cfa_offset 32
+	stp	x29, x30, [sp, #16]
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
@@ -160,14 +176,18 @@ LBB5_2:
 	bl	_objc_retainBlock
 Lloh8:
 	adrp	x8, _OBJC_IVAR_$_MACHView._mouseUp_block@PAGE
-	ldp	x29, x30, [sp, #16]
 Lloh9:
-	ldrsw	x10, [x8, _OBJC_IVAR_$_MACHView._mouseUp_block@PAGEOFF]
-	mov	x9, x0
-	ldr	x8, [x19, x10]
-	str	x9, [x19, x10]
+	ldrsw	x9, [x8, _OBJC_IVAR_$_MACHView._mouseUp_block@PAGEOFF]
+	ldr	x8, [x19, x9]
+	str	x0, [x19, x9]
 	mov	x0, x8
+	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
 	b	_objc_release
 LBB6_2:
 	ret
@@ -181,8 +201,8 @@ LBB6_2:
 	.cfi_startproc
 	cbz	x0, LBB7_2
 	stp	x20, x19, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
 	.cfi_def_cfa_offset 32
+	stp	x29, x30, [sp, #16]
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
@@ -192,14 +212,18 @@ LBB6_2:
 	bl	_objc_retainBlock
 Lloh10:
 	adrp	x8, _OBJC_IVAR_$_MACHView._scrollWheel_block@PAGE
-	ldp	x29, x30, [sp, #16]
 Lloh11:
-	ldrsw	x10, [x8, _OBJC_IVAR_$_MACHView._scrollWheel_block@PAGEOFF]
-	mov	x9, x0
-	ldr	x8, [x19, x10]
-	str	x9, [x19, x10]
+	ldrsw	x9, [x8, _OBJC_IVAR_$_MACHView._scrollWheel_block@PAGEOFF]
+	ldr	x8, [x19, x9]
+	str	x0, [x19, x9]
 	mov	x0, x8
+	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
 	b	_objc_release
 LBB7_2:
 	ret
@@ -213,8 +237,8 @@ LBB7_2:
 	.cfi_startproc
 	cbz	x0, LBB8_2
 	stp	x20, x19, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
 	.cfi_def_cfa_offset 32
+	stp	x29, x30, [sp, #16]
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
@@ -224,14 +248,18 @@ LBB7_2:
 	bl	_objc_retainBlock
 Lloh12:
 	adrp	x8, _OBJC_IVAR_$_MACHView._flagsChanged_block@PAGE
-	ldp	x29, x30, [sp, #16]
 Lloh13:
-	ldrsw	x10, [x8, _OBJC_IVAR_$_MACHView._flagsChanged_block@PAGEOFF]
-	mov	x9, x0
-	ldr	x8, [x19, x10]
-	str	x9, [x19, x10]
+	ldrsw	x9, [x8, _OBJC_IVAR_$_MACHView._flagsChanged_block@PAGEOFF]
+	ldr	x8, [x19, x9]
+	str	x0, [x19, x9]
 	mov	x0, x8
+	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
 	b	_objc_release
 LBB8_2:
 	ret
@@ -245,8 +273,8 @@ LBB8_2:
 	.cfi_startproc
 	cbz	x0, LBB9_2
 	stp	x20, x19, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
 	.cfi_def_cfa_offset 32
+	stp	x29, x30, [sp, #16]
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
@@ -256,14 +284,18 @@ LBB8_2:
 	bl	_objc_retainBlock
 Lloh14:
 	adrp	x8, _OBJC_IVAR_$_MACHView._insertText_block@PAGE
-	ldp	x29, x30, [sp, #16]
 Lloh15:
-	ldrsw	x10, [x8, _OBJC_IVAR_$_MACHView._insertText_block@PAGEOFF]
-	mov	x9, x0
-	ldr	x8, [x19, x10]
-	str	x9, [x19, x10]
+	ldrsw	x9, [x8, _OBJC_IVAR_$_MACHView._insertText_block@PAGEOFF]
+	ldr	x8, [x19, x9]
+	str	x0, [x19, x9]
 	mov	x0, x8
+	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
 	b	_objc_release
 LBB9_2:
 	ret
@@ -277,8 +309,8 @@ LBB9_2:
 	.cfi_startproc
 	cbz	x0, LBB10_2
 	stp	x20, x19, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
 	.cfi_def_cfa_offset 32
+	stp	x29, x30, [sp, #16]
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
@@ -288,14 +320,18 @@ LBB9_2:
 	bl	_objc_retainBlock
 Lloh16:
 	adrp	x8, _OBJC_IVAR_$_MACHView._magnify_block@PAGE
-	ldp	x29, x30, [sp, #16]
 Lloh17:
-	ldrsw	x10, [x8, _OBJC_IVAR_$_MACHView._magnify_block@PAGEOFF]
-	mov	x9, x0
-	ldr	x8, [x19, x10]
-	str	x9, [x19, x10]
+	ldrsw	x9, [x8, _OBJC_IVAR_$_MACHView._magnify_block@PAGEOFF]
+	ldr	x8, [x19, x9]
+	str	x0, [x19, x9]
 	mov	x0, x8
+	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
 	b	_objc_release
 LBB10_2:
 	ret
@@ -306,19 +342,19 @@ LBB10_2:
 "-[MACHView keyDown:]":
 	.cfi_startproc
 	sub	sp, sp, #64
+	.cfi_def_cfa_offset 64
 	stp	x22, x21, [sp, #16]
 	stp	x20, x19, [sp, #32]
 	stp	x29, x30, [sp, #48]
-	.cfi_def_cfa_offset 64
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
 	.cfi_offset w20, -32
 	.cfi_offset w21, -40
 	.cfi_offset w22, -48
+	mov	x19, x2
 	mov	x20, x0
 	mov	x0, x2
-	mov	x19, x2
 	bl	_objc_retain
 Lloh18:
 	adrp	x8, _OBJC_IVAR_$_MACHView._keyDown_block@PAGE
@@ -330,26 +366,26 @@ Lloh19:
 	mov	x1, x19
 	blr	x8
 LBB11_2:
+	str	x19, [sp, #8]
 Lloh20:
 	adrp	x8, _OBJC_CLASSLIST_REFERENCES_$_@PAGE
 Lloh21:
-	adrp	x9, _OBJC_SELECTOR_REFERENCES_@PAGE
-	add	x2, sp, #8
-Lloh22:
 	ldr	x0, [x8, _OBJC_CLASSLIST_REFERENCES_$_@PAGEOFF]
+Lloh22:
+	adrp	x8, _OBJC_SELECTOR_REFERENCES_@PAGE
 Lloh23:
-	ldr	x1, [x9, _OBJC_SELECTOR_REFERENCES_@PAGEOFF]
+	ldr	x1, [x8, _OBJC_SELECTOR_REFERENCES_@PAGEOFF]
+	add	x2, sp, #8
 	mov	w3, #1
-	str	x19, [sp, #8]
 	bl	_objc_msgSend
 	mov	x29, x29
 	bl	_objc_retainAutoreleasedReturnValue
+	mov	x21, x0
 Lloh24:
 	adrp	x8, _OBJC_SELECTOR_REFERENCES_.2@PAGE
-	mov	x21, x0
-	mov	x0, x20
 Lloh25:
 	ldr	x1, [x8, _OBJC_SELECTOR_REFERENCES_.2@PAGEOFF]
+	mov	x0, x20
 	mov	x2, x21
 	bl	_objc_msgSend
 	mov	x0, x21
@@ -360,23 +396,31 @@ Lloh25:
 	ldp	x20, x19, [sp, #32]
 	ldp	x22, x21, [sp, #16]
 	add	sp, sp, #64
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
+	.cfi_restore w21
+	.cfi_restore w22
 	ret
 	.loh AdrpLdr	Lloh18, Lloh19
 	.loh AdrpLdr	Lloh24, Lloh25
-	.loh AdrpLdr	Lloh21, Lloh23
-	.loh AdrpLdr	Lloh20, Lloh22
+	.loh AdrpLdr	Lloh22, Lloh23
+	.loh AdrpAdrp	Lloh20, Lloh22
+	.loh AdrpLdr	Lloh20, Lloh21
 	.cfi_endproc
 
 	.p2align	2
 "-[MACHView insertText:]":
 	.cfi_startproc
 	sub	sp, sp, #128
+	.cfi_def_cfa_offset 128
 	stp	x26, x25, [sp, #48]
 	stp	x24, x23, [sp, #64]
 	stp	x22, x21, [sp, #80]
 	stp	x20, x19, [sp, #96]
 	stp	x29, x30, [sp, #112]
-	.cfi_def_cfa_offset 128
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
@@ -387,47 +431,46 @@ Lloh25:
 	.cfi_offset w24, -64
 	.cfi_offset w25, -72
 	.cfi_offset w26, -80
+	mov	x19, x2
 	mov	x20, x0
 	mov	x0, x2
-	mov	x19, x2
 	bl	_objc_retain
 Lloh26:
 	adrp	x8, _NSApp@GOTPAGE
 Lloh27:
-	adrp	x9, _OBJC_SELECTOR_REFERENCES_.4@PAGE
-Lloh28:
 	ldr	x8, [x8, _NSApp@GOTPAGEOFF]
-Lloh29:
-	ldr	x1, [x9, _OBJC_SELECTOR_REFERENCES_.4@PAGEOFF]
-Lloh30:
+Lloh28:
 	ldr	x0, [x8]
+Lloh29:
+	adrp	x8, _OBJC_SELECTOR_REFERENCES_.4@PAGE
+Lloh30:
+	ldr	x1, [x8, _OBJC_SELECTOR_REFERENCES_.4@PAGEOFF]
 	bl	_objc_msgSend
 	mov	x29, x29
 	bl	_objc_retainAutoreleasedReturnValue
+	mov	x21, x0
 Lloh31:
 	adrp	x8, _OBJC_CLASSLIST_REFERENCES_$_.5@PAGE
 Lloh32:
-	adrp	x9, _OBJC_SELECTOR_REFERENCES_.7@PAGE
-	mov	x21, x0
+	ldr	x0, [x8, _OBJC_CLASSLIST_REFERENCES_$_.5@PAGEOFF]
 Lloh33:
-	ldr	x8, [x8, _OBJC_CLASSLIST_REFERENCES_$_.5@PAGEOFF]
+	adrp	x8, _OBJC_SELECTOR_REFERENCES_.7@PAGE
 Lloh34:
-	ldr	x1, [x9, _OBJC_SELECTOR_REFERENCES_.7@PAGEOFF]
-	mov	x0, x8
+	ldr	x1, [x8, _OBJC_SELECTOR_REFERENCES_.7@PAGEOFF]
 	bl	_objc_msgSend
+	mov	x2, x0
 Lloh35:
 	adrp	x8, _OBJC_SELECTOR_REFERENCES_.9@PAGE
-	mov	x2, x0
-	mov	x0, x19
 Lloh36:
 	ldr	x1, [x8, _OBJC_SELECTOR_REFERENCES_.9@PAGEOFF]
+	mov	x0, x19
 	bl	_objc_msgSend
 	cbz	w0, LBB12_2
 Lloh37:
 	adrp	x8, _OBJC_SELECTOR_REFERENCES_.11@PAGE
-	mov	x0, x19
 Lloh38:
 	ldr	x1, [x8, _OBJC_SELECTOR_REFERENCES_.11@PAGEOFF]
+	mov	x0, x19
 	bl	_objc_msgSend
 	mov	x29, x29
 	bl	_objc_retainAutoreleasedReturnValue
@@ -440,31 +483,31 @@ LBB12_2:
 LBB12_3:
 Lloh39:
 	adrp	x8, _OBJC_SELECTOR_REFERENCES_.13@PAGE
-	mov	x0, x22
 Lloh40:
 	ldr	x1, [x8, _OBJC_SELECTOR_REFERENCES_.13@PAGEOFF]
+	mov	x0, x22
 	bl	_objc_msgSend
 	stp	xzr, x0, [sp, #32]
 	cbz	x0, LBB12_10
 Lloh41:
 	adrp	x8, _OBJC_SELECTOR_REFERENCES_.15@PAGE
-	add	x24, sp, #32
-	adrp	x25, _OBJC_IVAR_$_MACHView._insertText_block@PAGE
 Lloh42:
 	ldr	x23, [x8, _OBJC_SELECTOR_REFERENCES_.15@PAGEOFF]
+	add	x24, sp, #32
+	adrp	x25, _OBJC_IVAR_$_MACHView._insertText_block@PAGE
 LBB12_5:
+	str	wzr, [sp, #28]
 	ldr	x8, [sp, #32]
-	mov	w5, #256
-	mov	x4, xzr
-	mov	x6, xzr
 	stp	x0, x24, [sp, #8]
 	add	x2, sp, #28
+	str	x8, [sp]
 	mov	x0, x22
 	mov	x1, x23
 	mov	w3, #4
+	mov	x4, #0
+	mov	w5, #256
 	movk	w5, #35840, lsl #16
-	str	wzr, [sp, #28]
-	str	x8, [sp]
+	mov	x6, #0
 	bl	_objc_msgSend
 	cbz	w0, LBB12_9
 	ldr	w2, [sp, #28]
@@ -493,12 +536,24 @@ LBB12_10:
 	ldp	x24, x23, [sp, #64]
 	ldp	x26, x25, [sp, #48]
 	add	sp, sp, #128
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
+	.cfi_restore w21
+	.cfi_restore w22
+	.cfi_restore w23
+	.cfi_restore w24
+	.cfi_restore w25
+	.cfi_restore w26
 	ret
 	.loh AdrpLdr	Lloh35, Lloh36
-	.loh AdrpLdr	Lloh32, Lloh34
-	.loh AdrpLdr	Lloh31, Lloh33
-	.loh AdrpLdr	Lloh27, Lloh29
-	.loh AdrpLdrGotLdr	Lloh26, Lloh28, Lloh30
+	.loh AdrpLdr	Lloh33, Lloh34
+	.loh AdrpAdrp	Lloh31, Lloh33
+	.loh AdrpLdr	Lloh31, Lloh32
+	.loh AdrpLdr	Lloh29, Lloh30
+	.loh AdrpLdrGotLdr	Lloh26, Lloh27, Lloh28
 	.loh AdrpLdr	Lloh37, Lloh38
 	.loh AdrpLdr	Lloh39, Lloh40
 	.loh AdrpLdr	Lloh41, Lloh42
@@ -743,14 +798,20 @@ LBB26_2:
 	.cfi_endproc
 
 	.p2align	2
+"-[MACHView doCommandBySelector:]":
+	.cfi_startproc
+	ret
+	.cfi_endproc
+
+	.p2align	2
 "-[MACHView initWithFrame:]":
 	.cfi_startproc
 	sub	sp, sp, #80
+	.cfi_def_cfa_offset 80
 	stp	d11, d10, [sp, #16]
 	stp	d9, d8, [sp, #32]
 	stp	x20, x19, [sp, #48]
 	stp	x29, x30, [sp, #64]
-	.cfi_def_cfa_offset 80
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
@@ -762,42 +823,42 @@ LBB26_2:
 Lloh71:
 	adrp	x8, l_OBJC_CLASSLIST_SUP_REFS_$_@PAGE
 Lloh72:
-	adrp	x9, _OBJC_SELECTOR_REFERENCES_.17@PAGE
-Lloh73:
 	ldr	x8, [x8, l_OBJC_CLASSLIST_SUP_REFS_$_@PAGEOFF]
-Lloh74:
-	ldr	x1, [x9, _OBJC_SELECTOR_REFERENCES_.17@PAGEOFF]
 	stp	x0, x8, [sp]
+Lloh73:
+	adrp	x8, _OBJC_SELECTOR_REFERENCES_.17@PAGE
+Lloh74:
+	ldr	x1, [x8, _OBJC_SELECTOR_REFERENCES_.17@PAGEOFF]
 	mov	x0, sp
 	bl	_objc_msgSendSuper2
 	mov	x19, x0
-	cbz	x0, LBB27_2
+	cbz	x0, LBB28_2
 Lloh75:
 	adrp	x8, _OBJC_SELECTOR_REFERENCES_.19@PAGE
-	mov	x0, x19
 Lloh76:
 	ldr	x1, [x8, _OBJC_SELECTOR_REFERENCES_.19@PAGEOFF]
+	mov	x0, x19
 	bl	_objc_msgSend
-Lloh77:
-	adrp	x8, _OBJC_CLASSLIST_REFERENCES_$_.20@PAGE
 	fmov	d8, d0
 	fmov	d9, d1
-Lloh78:
-	ldr	x0, [x8, _OBJC_CLASSLIST_REFERENCES_$_.20@PAGEOFF]
 	fmov	d10, d2
 	fmov	d11, d3
+Lloh77:
+	adrp	x8, _OBJC_CLASSLIST_REFERENCES_$_.20@PAGE
+Lloh78:
+	ldr	x0, [x8, _OBJC_CLASSLIST_REFERENCES_$_.20@PAGEOFF]
 	bl	_objc_alloc
-	fmov	d0, d8
-	fmov	d1, d9
 Lloh79:
 	adrp	x8, _OBJC_SELECTOR_REFERENCES_.22@PAGE
-	fmov	d2, d10
-	fmov	d3, d11
 Lloh80:
 	ldr	x1, [x8, _OBJC_SELECTOR_REFERENCES_.22@PAGEOFF]
+	fmov	d0, d8
+	fmov	d1, d9
+	fmov	d2, d10
+	fmov	d3, d11
 	mov	w2, #67
 	mov	x3, x19
-	mov	x4, xzr
+	mov	x4, #0
 	bl	_objc_msgSend
 Lloh81:
 	adrp	x8, _OBJC_IVAR_$_MACHView.trackingArea@PAGE
@@ -807,23 +868,32 @@ Lloh82:
 	str	x0, [x19, x20]
 	mov	x0, x8
 	bl	_objc_release
+	ldr	x2, [x19, x20]
 Lloh83:
 	adrp	x8, _OBJC_SELECTOR_REFERENCES_.24@PAGE
-	ldr	x2, [x19, x20]
-	mov	x0, x19
 Lloh84:
 	ldr	x1, [x8, _OBJC_SELECTOR_REFERENCES_.24@PAGEOFF]
+	mov	x0, x19
 	bl	_objc_msgSend
-LBB27_2:
+LBB28_2:
 	mov	x0, x19
 	ldp	x29, x30, [sp, #64]
 	ldp	x20, x19, [sp, #48]
 	ldp	d9, d8, [sp, #32]
 	ldp	d11, d10, [sp, #16]
 	add	sp, sp, #80
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
+	.cfi_restore b8
+	.cfi_restore b9
+	.cfi_restore b10
+	.cfi_restore b11
 	ret
-	.loh AdrpLdr	Lloh72, Lloh74
-	.loh AdrpLdr	Lloh71, Lloh73
+	.loh AdrpLdr	Lloh73, Lloh74
+	.loh AdrpLdr	Lloh71, Lloh72
 	.loh AdrpLdr	Lloh83, Lloh84
 	.loh AdrpLdr	Lloh81, Lloh82
 	.loh AdrpLdr	Lloh79, Lloh80
@@ -835,10 +905,10 @@ LBB27_2:
 "-[MACHView updateTrackingAreas]":
 	.cfi_startproc
 	stp	d11, d10, [sp, #-64]!
+	.cfi_def_cfa_offset 64
 	stp	d9, d8, [sp, #16]
 	stp	x20, x19, [sp, #32]
 	stp	x29, x30, [sp, #48]
-	.cfi_def_cfa_offset 64
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
@@ -847,58 +917,67 @@ LBB27_2:
 	.cfi_offset b9, -48
 	.cfi_offset b10, -56
 	.cfi_offset b11, -64
+	mov	x19, x0
 Lloh85:
 	adrp	x8, _OBJC_IVAR_$_MACHView.trackingArea@PAGE
-	mov	x19, x0
 Lloh86:
 	ldrsw	x20, [x8, _OBJC_IVAR_$_MACHView.trackingArea@PAGEOFF]
+	ldr	x2, [x0, x20]
 Lloh87:
 	adrp	x8, _OBJC_SELECTOR_REFERENCES_.26@PAGE
 Lloh88:
 	ldr	x1, [x8, _OBJC_SELECTOR_REFERENCES_.26@PAGEOFF]
-	ldr	x2, [x0, x20]
 	bl	_objc_msgSend
 Lloh89:
 	adrp	x8, _OBJC_SELECTOR_REFERENCES_.19@PAGE
-	mov	x0, x19
 Lloh90:
 	ldr	x1, [x8, _OBJC_SELECTOR_REFERENCES_.19@PAGEOFF]
+	mov	x0, x19
 	bl	_objc_msgSend
-Lloh91:
-	adrp	x8, _OBJC_CLASSLIST_REFERENCES_$_.20@PAGE
 	fmov	d8, d0
 	fmov	d9, d1
-Lloh92:
-	ldr	x0, [x8, _OBJC_CLASSLIST_REFERENCES_$_.20@PAGEOFF]
 	fmov	d10, d2
 	fmov	d11, d3
+Lloh91:
+	adrp	x8, _OBJC_CLASSLIST_REFERENCES_$_.20@PAGE
+Lloh92:
+	ldr	x0, [x8, _OBJC_CLASSLIST_REFERENCES_$_.20@PAGEOFF]
 	bl	_objc_alloc
-	fmov	d0, d8
-	fmov	d1, d9
 Lloh93:
 	adrp	x8, _OBJC_SELECTOR_REFERENCES_.22@PAGE
-	fmov	d2, d10
-	fmov	d3, d11
 Lloh94:
 	ldr	x1, [x8, _OBJC_SELECTOR_REFERENCES_.22@PAGEOFF]
+	fmov	d0, d8
+	fmov	d1, d9
+	fmov	d2, d10
+	fmov	d3, d11
 	mov	w2, #67
 	mov	x3, x19
-	mov	x4, xzr
+	mov	x4, #0
 	bl	_objc_msgSend
 	ldr	x8, [x19, x20]
 	str	x0, [x19, x20]
 	mov	x0, x8
 	bl	_objc_release
+	ldr	x2, [x19, x20]
 Lloh95:
 	adrp	x8, _OBJC_SELECTOR_REFERENCES_.24@PAGE
-	ldr	x2, [x19, x20]
-	mov	x0, x19
-	ldp	x29, x30, [sp, #48]
 Lloh96:
 	ldr	x1, [x8, _OBJC_SELECTOR_REFERENCES_.24@PAGEOFF]
+	mov	x0, x19
+	ldp	x29, x30, [sp, #48]
 	ldp	x20, x19, [sp, #32]
 	ldp	d9, d8, [sp, #16]
 	ldp	d11, d10, [sp], #64
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
+	.cfi_restore b8
+	.cfi_restore b9
+	.cfi_restore b10
+	.cfi_restore b11
 	b	_objc_msgSend
 	.loh AdrpLdr	Lloh95, Lloh96
 	.loh AdrpLdr	Lloh93, Lloh94
@@ -913,84 +992,89 @@ Lloh96:
 "-[MACHView .cxx_destruct]":
 	.cfi_startproc
 	stp	x20, x19, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
 	.cfi_def_cfa_offset 32
+	stp	x29, x30, [sp, #16]
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
 	.cfi_offset w20, -32
+	mov	x19, x0
 Lloh97:
 	adrp	x8, _OBJC_IVAR_$_MACHView.trackingArea@PAGE
-	mov	x19, x0
-	mov	x1, xzr
 Lloh98:
 	ldrsw	x8, [x8, _OBJC_IVAR_$_MACHView.trackingArea@PAGEOFF]
 	add	x0, x0, x8
+	mov	x1, #0
 	bl	_objc_storeStrong
 Lloh99:
 	adrp	x8, _OBJC_IVAR_$_MACHView._insertText_block@PAGE
-	mov	x1, xzr
 Lloh100:
 	ldrsw	x8, [x8, _OBJC_IVAR_$_MACHView._insertText_block@PAGEOFF]
 	add	x0, x19, x8
+	mov	x1, #0
 	bl	_objc_storeStrong
 Lloh101:
 	adrp	x8, _OBJC_IVAR_$_MACHView._magnify_block@PAGE
-	mov	x1, xzr
 Lloh102:
 	ldrsw	x8, [x8, _OBJC_IVAR_$_MACHView._magnify_block@PAGEOFF]
 	add	x0, x19, x8
+	mov	x1, #0
 	bl	_objc_storeStrong
 Lloh103:
 	adrp	x8, _OBJC_IVAR_$_MACHView._scrollWheel_block@PAGE
-	mov	x1, xzr
 Lloh104:
 	ldrsw	x8, [x8, _OBJC_IVAR_$_MACHView._scrollWheel_block@PAGEOFF]
 	add	x0, x19, x8
+	mov	x1, #0
 	bl	_objc_storeStrong
 Lloh105:
 	adrp	x8, _OBJC_IVAR_$_MACHView._mouseUp_block@PAGE
-	mov	x1, xzr
 Lloh106:
 	ldrsw	x8, [x8, _OBJC_IVAR_$_MACHView._mouseUp_block@PAGEOFF]
 	add	x0, x19, x8
+	mov	x1, #0
 	bl	_objc_storeStrong
 Lloh107:
 	adrp	x8, _OBJC_IVAR_$_MACHView._mouseDown_block@PAGE
-	mov	x1, xzr
 Lloh108:
 	ldrsw	x8, [x8, _OBJC_IVAR_$_MACHView._mouseDown_block@PAGEOFF]
 	add	x0, x19, x8
+	mov	x1, #0
 	bl	_objc_storeStrong
 Lloh109:
 	adrp	x8, _OBJC_IVAR_$_MACHView._mouseMoved_block@PAGE
-	mov	x1, xzr
 Lloh110:
 	ldrsw	x8, [x8, _OBJC_IVAR_$_MACHView._mouseMoved_block@PAGEOFF]
 	add	x0, x19, x8
+	mov	x1, #0
 	bl	_objc_storeStrong
 Lloh111:
 	adrp	x8, _OBJC_IVAR_$_MACHView._flagsChanged_block@PAGE
-	mov	x1, xzr
 Lloh112:
 	ldrsw	x8, [x8, _OBJC_IVAR_$_MACHView._flagsChanged_block@PAGEOFF]
 	add	x0, x19, x8
+	mov	x1, #0
 	bl	_objc_storeStrong
 Lloh113:
 	adrp	x8, _OBJC_IVAR_$_MACHView._keyUp_block@PAGE
-	mov	x1, xzr
 Lloh114:
 	ldrsw	x8, [x8, _OBJC_IVAR_$_MACHView._keyUp_block@PAGEOFF]
 	add	x0, x19, x8
+	mov	x1, #0
 	bl	_objc_storeStrong
 Lloh115:
 	adrp	x8, _OBJC_IVAR_$_MACHView._keyDown_block@PAGE
-	ldp	x29, x30, [sp, #16]
 Lloh116:
 	ldrsw	x8, [x8, _OBJC_IVAR_$_MACHView._keyDown_block@PAGEOFF]
-	mov	x1, xzr
 	add	x0, x19, x8
+	mov	x1, #0
+	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
 	b	_objc_storeStrong
 	.loh AdrpLdr	Lloh115, Lloh116
 	.loh AdrpLdr	Lloh113, Lloh114
@@ -1311,27 +1395,33 @@ l_OBJC_METH_VAR_NAME_.45:
 l_OBJC_METH_VAR_NAME_.46:
 	.asciz	"magnifyWithEvent:"
 
+l_OBJC_METH_VAR_NAME_.47:
+	.asciz	"doCommandBySelector:"
+
 	.section	__TEXT,__objc_methtype,cstring_literals
-l_OBJC_METH_VAR_TYPE_.47:
+l_OBJC_METH_VAR_TYPE_.48:
+	.asciz	"v24@0:8:16"
+
+l_OBJC_METH_VAR_TYPE_.49:
 	.asciz	"@48@0:8{CGRect={CGPoint=dd}{CGSize=dd}}16"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-l_OBJC_METH_VAR_NAME_.48:
+l_OBJC_METH_VAR_NAME_.50:
 	.asciz	"updateTrackingAreas"
 
 	.section	__TEXT,__objc_methtype,cstring_literals
-l_OBJC_METH_VAR_TYPE_.49:
+l_OBJC_METH_VAR_TYPE_.51:
 	.asciz	"v16@0:8"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-l_OBJC_METH_VAR_NAME_.50:
+l_OBJC_METH_VAR_NAME_.52:
 	.asciz	".cxx_destruct"
 
 	.section	__DATA,__objc_const
 	.p2align	3, 0x0
 __OBJC_$_INSTANCE_METHODS_MACHView:
 	.long	24
-	.long	21
+	.long	22
 	.quad	l_OBJC_METH_VAR_NAME_.28
 	.quad	l_OBJC_METH_VAR_TYPE_
 	.quad	"-[MACHView canBecomeKeyView]"
@@ -1386,54 +1476,57 @@ __OBJC_$_INSTANCE_METHODS_MACHView:
 	.quad	l_OBJC_METH_VAR_NAME_.46
 	.quad	l_OBJC_METH_VAR_TYPE_.31
 	.quad	"-[MACHView magnifyWithEvent:]"
+	.quad	l_OBJC_METH_VAR_NAME_.47
+	.quad	l_OBJC_METH_VAR_TYPE_.48
+	.quad	"-[MACHView doCommandBySelector:]"
 	.quad	l_OBJC_METH_VAR_NAME_.16
-	.quad	l_OBJC_METH_VAR_TYPE_.47
+	.quad	l_OBJC_METH_VAR_TYPE_.49
 	.quad	"-[MACHView initWithFrame:]"
-	.quad	l_OBJC_METH_VAR_NAME_.48
-	.quad	l_OBJC_METH_VAR_TYPE_.49
-	.quad	"-[MACHView updateTrackingAreas]"
 	.quad	l_OBJC_METH_VAR_NAME_.50
-	.quad	l_OBJC_METH_VAR_TYPE_.49
+	.quad	l_OBJC_METH_VAR_TYPE_.51
+	.quad	"-[MACHView updateTrackingAreas]"
+	.quad	l_OBJC_METH_VAR_NAME_.52
+	.quad	l_OBJC_METH_VAR_TYPE_.51
 	.quad	"-[MACHView .cxx_destruct]"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-l_OBJC_METH_VAR_NAME_.51:
+l_OBJC_METH_VAR_NAME_.53:
 	.asciz	"_keyDown_block"
 
 	.section	__TEXT,__objc_methtype,cstring_literals
-l_OBJC_METH_VAR_TYPE_.52:
+l_OBJC_METH_VAR_TYPE_.54:
 	.asciz	"@?"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-l_OBJC_METH_VAR_NAME_.53:
+l_OBJC_METH_VAR_NAME_.55:
 	.asciz	"_keyUp_block"
 
-l_OBJC_METH_VAR_NAME_.54:
+l_OBJC_METH_VAR_NAME_.56:
 	.asciz	"_flagsChanged_block"
 
-l_OBJC_METH_VAR_NAME_.55:
+l_OBJC_METH_VAR_NAME_.57:
 	.asciz	"_mouseMoved_block"
 
-l_OBJC_METH_VAR_NAME_.56:
+l_OBJC_METH_VAR_NAME_.58:
 	.asciz	"_mouseDown_block"
 
-l_OBJC_METH_VAR_NAME_.57:
+l_OBJC_METH_VAR_NAME_.59:
 	.asciz	"_mouseUp_block"
 
-l_OBJC_METH_VAR_NAME_.58:
+l_OBJC_METH_VAR_NAME_.60:
 	.asciz	"_scrollWheel_block"
 
-l_OBJC_METH_VAR_NAME_.59:
+l_OBJC_METH_VAR_NAME_.61:
 	.asciz	"_magnify_block"
 
-l_OBJC_METH_VAR_NAME_.60:
+l_OBJC_METH_VAR_NAME_.62:
 	.asciz	"_insertText_block"
 
-l_OBJC_METH_VAR_NAME_.61:
+l_OBJC_METH_VAR_NAME_.63:
 	.asciz	"trackingArea"
 
 	.section	__TEXT,__objc_methtype,cstring_literals
-l_OBJC_METH_VAR_TYPE_.62:
+l_OBJC_METH_VAR_TYPE_.64:
 	.asciz	"@\"NSTrackingArea\""
 
 	.section	__DATA,__objc_const
@@ -1442,53 +1535,53 @@ __OBJC_$_INSTANCE_VARIABLES_MACHView:
 	.long	32
 	.long	10
 	.quad	_OBJC_IVAR_$_MACHView._keyDown_block
-	.quad	l_OBJC_METH_VAR_NAME_.51
-	.quad	l_OBJC_METH_VAR_TYPE_.52
+	.quad	l_OBJC_METH_VAR_NAME_.53
+	.quad	l_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._keyUp_block
-	.quad	l_OBJC_METH_VAR_NAME_.53
-	.quad	l_OBJC_METH_VAR_TYPE_.52
+	.quad	l_OBJC_METH_VAR_NAME_.55
+	.quad	l_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._flagsChanged_block
-	.quad	l_OBJC_METH_VAR_NAME_.54
-	.quad	l_OBJC_METH_VAR_TYPE_.52
+	.quad	l_OBJC_METH_VAR_NAME_.56
+	.quad	l_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._mouseMoved_block
-	.quad	l_OBJC_METH_VAR_NAME_.55
-	.quad	l_OBJC_METH_VAR_TYPE_.52
+	.quad	l_OBJC_METH_VAR_NAME_.57
+	.quad	l_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._mouseDown_block
-	.quad	l_OBJC_METH_VAR_NAME_.56
-	.quad	l_OBJC_METH_VAR_TYPE_.52
+	.quad	l_OBJC_METH_VAR_NAME_.58
+	.quad	l_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._mouseUp_block
-	.quad	l_OBJC_METH_VAR_NAME_.57
-	.quad	l_OBJC_METH_VAR_TYPE_.52
+	.quad	l_OBJC_METH_VAR_NAME_.59
+	.quad	l_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._scrollWheel_block
-	.quad	l_OBJC_METH_VAR_NAME_.58
-	.quad	l_OBJC_METH_VAR_TYPE_.52
+	.quad	l_OBJC_METH_VAR_NAME_.60
+	.quad	l_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._magnify_block
-	.quad	l_OBJC_METH_VAR_NAME_.59
-	.quad	l_OBJC_METH_VAR_TYPE_.52
+	.quad	l_OBJC_METH_VAR_NAME_.61
+	.quad	l_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._insertText_block
-	.quad	l_OBJC_METH_VAR_NAME_.60
-	.quad	l_OBJC_METH_VAR_TYPE_.52
+	.quad	l_OBJC_METH_VAR_NAME_.62
+	.quad	l_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView.trackingArea
-	.quad	l_OBJC_METH_VAR_NAME_.61
-	.quad	l_OBJC_METH_VAR_TYPE_.62
+	.quad	l_OBJC_METH_VAR_NAME_.63
+	.quad	l_OBJC_METH_VAR_TYPE_.64
 	.long	3
 	.long	8
 

--- a/MACHView_x86_64_apple_macos12.s
+++ b/MACHView_x86_64_apple_macos12.s
@@ -336,8 +336,10 @@ LBB12_3:
 	leaq	44(%rsp), %rbp
 LBB12_5:
 	movl	$0, 44(%rsp)
-	movups	56(%rsp), %xmm0
-	movups	%xmm0, 8(%rsp)
+	movq	56(%rsp), %rax
+	movq	64(%rsp), %rcx
+	movq	%rcx, 16(%rsp)
+	movq	%rax, 8(%rsp)
 	movq	%r14, 24(%rsp)
 	movq	$0, (%rsp)
 	movl	$4, %ecx
@@ -577,6 +579,12 @@ LBB26_1:
 	retq
 	.cfi_endproc
 
+"-[MACHView doCommandBySelector:]":
+
+	.cfi_startproc
+	retq
+	.cfi_endproc
+
 "-[MACHView initWithFrame:]":
 
 	.cfi_startproc
@@ -596,15 +604,19 @@ LBB26_1:
 	movq	l_OBJC_CLASSLIST_SUP_REFS_$_(%rip), %rcx
 	movq	%rcx, 8(%rax)
 	movq	_OBJC_SELECTOR_REFERENCES_.17(%rip), %rsi
-	movaps	112(%rsp), %xmm0
-	movaps	128(%rsp), %xmm1
-	movups	%xmm1, 16(%rsp)
-	movups	%xmm0, (%rsp)
+	movq	136(%rsp), %rcx
+	movq	%rcx, 24(%rsp)
+	movq	128(%rsp), %rcx
+	movq	%rcx, 16(%rsp)
+	movq	112(%rsp), %rcx
+	movq	120(%rsp), %rdx
+	movq	%rdx, 8(%rsp)
+	movq	%rcx, (%rsp)
 	movq	%rax, %rdi
 	callq	_objc_msgSendSuper2
 	movq	%rax, %rbx
 	testq	%rax, %rax
-	je	LBB27_2
+	je	LBB28_2
 	movq	_OBJC_SELECTOR_REFERENCES_.19(%rip), %rdx
 	leaq	48(%rsp), %r14
 	movq	%r14, %rdi
@@ -613,10 +625,14 @@ LBB26_1:
 	movq	_OBJC_CLASSLIST_REFERENCES_$_.20(%rip), %rdi
 	callq	_objc_alloc
 	movq	_OBJC_SELECTOR_REFERENCES_.22(%rip), %rsi
-	movups	(%r14), %xmm0
-	movups	16(%r14), %xmm1
-	movups	%xmm1, 16(%rsp)
-	movups	%xmm0, (%rsp)
+	movq	24(%r14), %rcx
+	movq	%rcx, 24(%rsp)
+	movq	16(%r14), %rcx
+	movq	%rcx, 16(%rsp)
+	movq	(%r14), %rcx
+	movq	8(%r14), %rdx
+	movq	%rdx, 8(%rsp)
+	movq	%rcx, (%rsp)
 	movq	_objc_msgSend@GOTPCREL(%rip), %r14
 	movl	$67, %edx
 	movq	%rax, %rdi
@@ -631,7 +647,7 @@ LBB26_1:
 	movq	_OBJC_SELECTOR_REFERENCES_.24(%rip), %rsi
 	movq	%rbx, %rdi
 	callq	*%r14
-LBB27_2:
+LBB28_2:
 	movq	%rbx, %rax
 	addq	$80, %rsp
 	popq	%rbx
@@ -671,10 +687,14 @@ LBB27_2:
 	movq	_OBJC_CLASSLIST_REFERENCES_$_.20(%rip), %rdi
 	callq	_objc_alloc
 	movq	_OBJC_SELECTOR_REFERENCES_.22(%rip), %rsi
-	movups	(%r14), %xmm0
-	movups	16(%r14), %xmm1
-	movups	%xmm1, 16(%rsp)
-	movups	%xmm0, (%rsp)
+	movq	24(%r14), %rcx
+	movq	%rcx, 24(%rsp)
+	movq	16(%r14), %rcx
+	movq	%rcx, 16(%rsp)
+	movq	(%r14), %rcx
+	movq	8(%r14), %rdx
+	movq	%rdx, 8(%rsp)
+	movq	%rcx, (%rsp)
 	movl	$67, %edx
 	movq	%rax, %rdi
 	movq	%rbx, %rcx
@@ -1052,27 +1072,33 @@ L_OBJC_METH_VAR_NAME_.45:
 L_OBJC_METH_VAR_NAME_.46:
 	.asciz	"magnifyWithEvent:"
 
+L_OBJC_METH_VAR_NAME_.47:
+	.asciz	"doCommandBySelector:"
+
 	.section	__TEXT,__objc_methtype,cstring_literals
-L_OBJC_METH_VAR_TYPE_.47:
+L_OBJC_METH_VAR_TYPE_.48:
+	.asciz	"v24@0:8:16"
+
+L_OBJC_METH_VAR_TYPE_.49:
 	.asciz	"@48@0:8{CGRect={CGPoint=dd}{CGSize=dd}}16"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-L_OBJC_METH_VAR_NAME_.48:
+L_OBJC_METH_VAR_NAME_.50:
 	.asciz	"updateTrackingAreas"
 
 	.section	__TEXT,__objc_methtype,cstring_literals
-L_OBJC_METH_VAR_TYPE_.49:
+L_OBJC_METH_VAR_TYPE_.51:
 	.asciz	"v16@0:8"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-L_OBJC_METH_VAR_NAME_.50:
+L_OBJC_METH_VAR_NAME_.52:
 	.asciz	".cxx_destruct"
 
 	.section	__DATA,__objc_const
 	.p2align	3, 0x0
 __OBJC_$_INSTANCE_METHODS_MACHView:
 	.long	24
-	.long	21
+	.long	22
 	.quad	L_OBJC_METH_VAR_NAME_.28
 	.quad	L_OBJC_METH_VAR_TYPE_
 	.quad	"-[MACHView canBecomeKeyView]"
@@ -1127,54 +1153,57 @@ __OBJC_$_INSTANCE_METHODS_MACHView:
 	.quad	L_OBJC_METH_VAR_NAME_.46
 	.quad	L_OBJC_METH_VAR_TYPE_.31
 	.quad	"-[MACHView magnifyWithEvent:]"
+	.quad	L_OBJC_METH_VAR_NAME_.47
+	.quad	L_OBJC_METH_VAR_TYPE_.48
+	.quad	"-[MACHView doCommandBySelector:]"
 	.quad	L_OBJC_METH_VAR_NAME_.16
-	.quad	L_OBJC_METH_VAR_TYPE_.47
+	.quad	L_OBJC_METH_VAR_TYPE_.49
 	.quad	"-[MACHView initWithFrame:]"
-	.quad	L_OBJC_METH_VAR_NAME_.48
-	.quad	L_OBJC_METH_VAR_TYPE_.49
-	.quad	"-[MACHView updateTrackingAreas]"
 	.quad	L_OBJC_METH_VAR_NAME_.50
-	.quad	L_OBJC_METH_VAR_TYPE_.49
+	.quad	L_OBJC_METH_VAR_TYPE_.51
+	.quad	"-[MACHView updateTrackingAreas]"
+	.quad	L_OBJC_METH_VAR_NAME_.52
+	.quad	L_OBJC_METH_VAR_TYPE_.51
 	.quad	"-[MACHView .cxx_destruct]"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-L_OBJC_METH_VAR_NAME_.51:
+L_OBJC_METH_VAR_NAME_.53:
 	.asciz	"_keyDown_block"
 
 	.section	__TEXT,__objc_methtype,cstring_literals
-L_OBJC_METH_VAR_TYPE_.52:
+L_OBJC_METH_VAR_TYPE_.54:
 	.asciz	"@?"
 
 	.section	__TEXT,__objc_methname,cstring_literals
-L_OBJC_METH_VAR_NAME_.53:
+L_OBJC_METH_VAR_NAME_.55:
 	.asciz	"_keyUp_block"
 
-L_OBJC_METH_VAR_NAME_.54:
+L_OBJC_METH_VAR_NAME_.56:
 	.asciz	"_flagsChanged_block"
 
-L_OBJC_METH_VAR_NAME_.55:
+L_OBJC_METH_VAR_NAME_.57:
 	.asciz	"_mouseMoved_block"
 
-L_OBJC_METH_VAR_NAME_.56:
+L_OBJC_METH_VAR_NAME_.58:
 	.asciz	"_mouseDown_block"
 
-L_OBJC_METH_VAR_NAME_.57:
+L_OBJC_METH_VAR_NAME_.59:
 	.asciz	"_mouseUp_block"
 
-L_OBJC_METH_VAR_NAME_.58:
+L_OBJC_METH_VAR_NAME_.60:
 	.asciz	"_scrollWheel_block"
 
-L_OBJC_METH_VAR_NAME_.59:
+L_OBJC_METH_VAR_NAME_.61:
 	.asciz	"_magnify_block"
 
-L_OBJC_METH_VAR_NAME_.60:
+L_OBJC_METH_VAR_NAME_.62:
 	.asciz	"_insertText_block"
 
-L_OBJC_METH_VAR_NAME_.61:
+L_OBJC_METH_VAR_NAME_.63:
 	.asciz	"trackingArea"
 
 	.section	__TEXT,__objc_methtype,cstring_literals
-L_OBJC_METH_VAR_TYPE_.62:
+L_OBJC_METH_VAR_TYPE_.64:
 	.asciz	"@\"NSTrackingArea\""
 
 	.section	__DATA,__objc_const
@@ -1183,53 +1212,53 @@ __OBJC_$_INSTANCE_VARIABLES_MACHView:
 	.long	32
 	.long	10
 	.quad	_OBJC_IVAR_$_MACHView._keyDown_block
-	.quad	L_OBJC_METH_VAR_NAME_.51
-	.quad	L_OBJC_METH_VAR_TYPE_.52
+	.quad	L_OBJC_METH_VAR_NAME_.53
+	.quad	L_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._keyUp_block
-	.quad	L_OBJC_METH_VAR_NAME_.53
-	.quad	L_OBJC_METH_VAR_TYPE_.52
+	.quad	L_OBJC_METH_VAR_NAME_.55
+	.quad	L_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._flagsChanged_block
-	.quad	L_OBJC_METH_VAR_NAME_.54
-	.quad	L_OBJC_METH_VAR_TYPE_.52
+	.quad	L_OBJC_METH_VAR_NAME_.56
+	.quad	L_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._mouseMoved_block
-	.quad	L_OBJC_METH_VAR_NAME_.55
-	.quad	L_OBJC_METH_VAR_TYPE_.52
+	.quad	L_OBJC_METH_VAR_NAME_.57
+	.quad	L_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._mouseDown_block
-	.quad	L_OBJC_METH_VAR_NAME_.56
-	.quad	L_OBJC_METH_VAR_TYPE_.52
+	.quad	L_OBJC_METH_VAR_NAME_.58
+	.quad	L_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._mouseUp_block
-	.quad	L_OBJC_METH_VAR_NAME_.57
-	.quad	L_OBJC_METH_VAR_TYPE_.52
+	.quad	L_OBJC_METH_VAR_NAME_.59
+	.quad	L_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._scrollWheel_block
-	.quad	L_OBJC_METH_VAR_NAME_.58
-	.quad	L_OBJC_METH_VAR_TYPE_.52
+	.quad	L_OBJC_METH_VAR_NAME_.60
+	.quad	L_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._magnify_block
-	.quad	L_OBJC_METH_VAR_NAME_.59
-	.quad	L_OBJC_METH_VAR_TYPE_.52
+	.quad	L_OBJC_METH_VAR_NAME_.61
+	.quad	L_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView._insertText_block
-	.quad	L_OBJC_METH_VAR_NAME_.60
-	.quad	L_OBJC_METH_VAR_TYPE_.52
+	.quad	L_OBJC_METH_VAR_NAME_.62
+	.quad	L_OBJC_METH_VAR_TYPE_.54
 	.long	3
 	.long	8
 	.quad	_OBJC_IVAR_$_MACHView.trackingArea
-	.quad	L_OBJC_METH_VAR_NAME_.61
-	.quad	L_OBJC_METH_VAR_TYPE_.62
+	.quad	L_OBJC_METH_VAR_NAME_.63
+	.quad	L_OBJC_METH_VAR_TYPE_.64
 	.long	3
 	.long	8
 

--- a/MACHWindowDelegate_arm64_apple_macos12.s
+++ b/MACHWindowDelegate_arm64_apple_macos12.s
@@ -7,8 +7,8 @@
 	.cfi_startproc
 	cbz	x0, LBB0_2
 	stp	x20, x19, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
 	.cfi_def_cfa_offset 32
+	stp	x29, x30, [sp, #16]
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
@@ -17,11 +17,15 @@
 	mov	x0, x1
 	bl	_objc_retainBlock
 	ldr	x8, [x19, #8]
-	ldp	x29, x30, [sp, #16]
-	mov	x9, x0
+	str	x0, [x19, #8]
 	mov	x0, x8
-	str	x9, [x19, #8]
+	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
 	b	_objc_release
 LBB0_2:
 	ret
@@ -34,8 +38,8 @@ LBB0_2:
 	.cfi_startproc
 	cbz	x0, LBB1_2
 	stp	x20, x19, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
 	.cfi_def_cfa_offset 32
+	stp	x29, x30, [sp, #16]
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
@@ -44,11 +48,15 @@ LBB0_2:
 	mov	x0, x1
 	bl	_objc_retainBlock
 	ldr	x8, [x19, #16]
-	ldp	x29, x30, [sp, #16]
-	mov	x9, x0
+	str	x0, [x19, #16]
 	mov	x0, x8
-	str	x9, [x19, #16]
+	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
 	b	_objc_release
 LBB1_2:
 	ret
@@ -77,8 +85,11 @@ LBB2_2:
 	ldr	x8, [x0, #16]
 	blr	x8
 	ldp	x29, x30, [sp], #16
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
 LBB3_2:
-	mov	w0, wzr
+	mov	w0, #0
 	ret
 	.cfi_endproc
 
@@ -92,20 +103,25 @@ LBB3_2:
 "-[MACHWindowDelegate .cxx_destruct]":
 	.cfi_startproc
 	stp	x20, x19, [sp, #-32]!
-	stp	x29, x30, [sp, #16]
 	.cfi_def_cfa_offset 32
+	stp	x29, x30, [sp, #16]
 	.cfi_offset w30, -8
 	.cfi_offset w29, -16
 	.cfi_offset w19, -24
 	.cfi_offset w20, -32
 	mov	x19, x0
 	add	x0, x0, #16
-	mov	x1, xzr
+	mov	x1, #0
 	bl	_objc_storeStrong
-	ldp	x29, x30, [sp, #16]
 	add	x0, x19, #8
-	mov	x1, xzr
+	mov	x1, #0
+	ldp	x29, x30, [sp, #16]
 	ldp	x20, x19, [sp], #32
+	.cfi_def_cfa_offset 0
+	.cfi_restore w30
+	.cfi_restore w29
+	.cfi_restore w19
+	.cfi_restore w20
 	b	_objc_storeStrong
 	.cfi_endproc
 


### PR DESCRIPTION
This should fix the issue on macos where escape pulls you out of fullscreen, arrow keys cause an error sound, etc. by overriding a method that handles the default macos keybinds. This is the same fix GLFW implements.

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.